### PR TITLE
feat: tighten landing spacing and density

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -220,8 +220,8 @@ export default function Page() {
 
   return (
     <main className="pb-24 md:pb-0">
-      <section id="hero" className="hero-surface relative overflow-hidden pb-16 pt-24 lg:pt-28">
-        <div className="container-soft grid items-center gap-12 lg:grid-cols-[minmax(0,1fr)_minmax(0,420px)]">
+      <section id="hero" className="hero-surface relative overflow-hidden pb-12 pt-20 md:pb-16 md:pt-24">
+        <div className="container-soft grid items-center gap-10 md:gap-12 lg:grid-cols-[minmax(0,1fr)_minmax(0,420px)]">
           <div className="space-y-6">
             <span className="inline-flex items-center gap-2 rounded-full bg-white/80 px-4 py-2 text-sm font-semibold text-primary">
               Понятный помощник
@@ -255,7 +255,7 @@ export default function Page() {
               ))}
             </div>
           </div>
-          <Card className="relative overflow-hidden border border-white/60 bg-white/90 p-0 shadow-[0_32px_80px_-44px_rgba(15,18,34,0.6)]">
+          <Card className="relative overflow-hidden border border-white/60 bg-white/90 p-0 shadow-[0_24px_60px_-36px_rgba(15,18,34,0.3)]">
             <div className="space-y-5 p-6">
               <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-[0.2em] text-muted">
                 <span>Рецепт</span>
@@ -315,7 +315,7 @@ export default function Page() {
         title="Как это работает"
         subtitle="Три понятных шага — и всё готово."
       >
-        <div className="grid gap-6 md:grid-cols-3">
+        <div className="grid gap-5 md:grid-cols-3">
           {howSteps.map((step) => (
             <Card key={step.id} className="flex flex-col gap-4 p-0">
               <Image
@@ -342,8 +342,8 @@ export default function Page() {
         </div>
       </Section>
 
-      <Section id="recipes" title="Готовые рецепты" subtitle="Начните с простого — так быстрее получается.">
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+      <Section id="recipes" title="Готовые рецепты" subtitle="Начните с простого — так быстрее получается." spacing="tight">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
           <div className="w-full max-w-xl">
             <label htmlFor="recipe-search" className="sr-only">
               Напишите, что нужно сделать — мы предложим рецепт
@@ -395,7 +395,7 @@ export default function Page() {
             ))}
           </div>
         </div>
-        <div className="mt-8 grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+        <div className="mt-8 grid grid-cols-1 gap-3 md:grid-cols-2 md:gap-4 xl:grid-cols-3">
           {featuredRecipes.map((recipe) => (
             <div key={recipe.id} className="md:col-span-2 xl:col-span-1">
               <RecipeCard recipe={recipe} tab={activeTab} onLaunch={handleLaunchRecipe} variant="featured" />
@@ -415,7 +415,7 @@ export default function Page() {
         </div>
       </Section>
 
-      <Section id="chat" title="Обычный чат" subtitle="Можно говорить голосом или писать текстом.">
+      <Section id="chat" title="Обычный чат" subtitle="Можно говорить голосом или писать текстом." spacing="tight" tone="muted">
         <Card className="space-y-5">
           <div className="flex items-center gap-3 rounded-[20px] border border-neutral-200 bg-white px-4 py-5">
             <button
@@ -457,12 +457,12 @@ export default function Page() {
         <ModelTable />
       </Section>
 
-      <Section id="privacy" title="Приватность" subtitle="Вы решаете, что хранить.">
+      <Section id="privacy" title="Приватность" subtitle="Вы решаете, что хранить." spacing="tight">
         <div className="mb-6 inline-flex items-center gap-2 rounded-full bg-white px-4 py-2 text-xs font-semibold text-muted">
           <span aria-hidden>🛡️</span>
           Надёжные провайдеры в ЕС • Совместимо с требованиями РФ
         </div>
-        <div className="grid gap-4 md:grid-cols-3">
+        <div className="grid gap-3 md:grid-cols-3 md:gap-4">
           {privacyCards.map((card) => (
             <Card key={card.title} className="flex h-full flex-col justify-between">
               <div>
@@ -486,7 +486,7 @@ export default function Page() {
         title="Тарифы"
         subtitle="Оплата картой, СБП и МИР. Отмена — в один клик."
       >
-        <div className="grid gap-4 md:grid-cols-3">
+        <div className="grid gap-3 md:grid-cols-3 md:gap-4">
           {plans.map((plan) => (
             <Card
               key={plan.id}
@@ -535,10 +535,10 @@ export default function Page() {
         )}
       </Section>
 
-      <Section id="testimonials" title="Отзывы" subtitle="До и после — коротко и по делу.">
-        <div className="flex flex-col gap-4">
+      <Section id="testimonials" title="Отзывы" subtitle="До и после — коротко и по делу." spacing="tight" tone="muted">
+        <div className="flex flex-col gap-3">
           <div className="text-sm font-semibold text-muted">★ 4,8 (за 30 дней)</div>
-          <div className="-mx-6 flex snap-x snap-mandatory gap-4 overflow-x-auto px-6 pb-4" role="region" aria-label="Истории пользователей">
+          <div className="-mx-6 flex snap-x snap-mandatory gap-3 overflow-x-auto px-6 pb-4" role="region" aria-label="Истории пользователей">
             {testimonials.map((testimonial) => (
               <TestimonialCard key={testimonial.id} {...testimonial} />
             ))}
@@ -556,8 +556,8 @@ export default function Page() {
         </div>
       </Section>
 
-      <Section id="faq" title="FAQ" subtitle="Ответы на самые частые вопросы.">
-        <div className="grid gap-4 md:grid-cols-2">
+      <Section id="faq" title="FAQ" subtitle="Ответы на самые частые вопросы." spacing="tight">
+        <div className="grid gap-3 md:grid-cols-2 md:gap-4">
           {faqs.map((faq) => (
             <FAQItem key={faq.id} {...faq} />
           ))}

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -5,7 +5,7 @@ export default function Card({ className, ...props }: HTMLAttributes<HTMLDivElem
   return (
     <div
       className={clsx(
-        "rounded-[20px] border border-neutral-200/70 bg-white/95 p-6 shadow-[0_24px_64px_-40px_rgba(15,18,34,0.45)] transition-all hover:-translate-y-0.5 hover:shadow-[0_32px_80px_-36px_rgba(15,18,34,0.55)]",
+        "rounded-[20px] border border-neutral-200/70 bg-white/95 p-5 shadow-[0_16px_40px_-28px_rgba(15,18,34,0.18)] transition-all hover:-translate-y-0.5 hover:shadow-[0_24px_56px_-28px_rgba(15,18,34,0.22)] md:p-6",
         className
       )}
       {...props}

--- a/components/Section.tsx
+++ b/components/Section.tsx
@@ -1,6 +1,9 @@
 import { ReactNode } from "react";
 import clsx from "clsx";
 
+type SectionSpacing = "normal" | "tight";
+type SectionTone = "default" | "muted";
+
 type Props = {
   id?: string;
   title: string;
@@ -8,13 +11,39 @@ type Props = {
   eyebrow?: string;
   children: ReactNode;
   className?: string;
+  spacing?: SectionSpacing;
+  tone?: SectionTone;
 };
 
-export default function Section({ id, title, subtitle, eyebrow, children, className }: Props) {
+const spacingClasses: Record<SectionSpacing, string> = {
+  normal: "py-14 md:py-20",
+  tight: "py-10 md:py-14"
+};
+
+const headerSpacing: Record<SectionSpacing, string> = {
+  normal: "mb-12",
+  tight: "mb-8"
+};
+
+const toneClasses: Record<SectionTone, string> = {
+  default: "",
+  muted: "bg-muted"
+};
+
+export default function Section({
+  id,
+  title,
+  subtitle,
+  eyebrow,
+  children,
+  className,
+  spacing = "normal",
+  tone = "default"
+}: Props) {
   return (
-    <section id={id} className={clsx("py-16 lg:py-24", className)}>
+    <section id={id} className={clsx(spacingClasses[spacing], toneClasses[tone], className)}>
       <div className="container-soft">
-        <div className="mb-10 max-w-3xl">
+        <div className={clsx("max-w-3xl", headerSpacing[spacing])}>
           {eyebrow && <span className="text-sm font-semibold uppercase tracking-[0.24em] text-primary">{eyebrow}</span>}
           <h2 className="mt-3 text-[32px] font-semibold leading-[1.2] text-text md:text-4xl" style={{ fontFamily: "var(--font-jost)" }}>
             {title}


### PR DESCRIPTION
## Summary
- add `spacing`/`tone` options to `Section` to alternate vertical rhythm and muted backgrounds
- soften card padding and shadows to reduce visual plasticity
- tighten hero spacing and grid gaps across key sections to remove empty vertical air

## Testing
- npm run build

## Screenshots
### Desktop hero
- Before: ![Desktop hero before](browser:/invocations/ghdgurxw/artifacts/artifacts/hero-desktop-before.png)
- After: ![Desktop hero after](browser:/invocations/eteixjfv/artifacts/artifacts/hero-desktop.png)

### Desktop recipes
- Before: ![Desktop recipes before](browser:/invocations/ghdgurxw/artifacts/artifacts/recipes-desktop-before.png)
- After: ![Desktop recipes after](browser:/invocations/eteixjfv/artifacts/artifacts/recipes-desktop.png)

### Mobile hero
- Before: ![Mobile hero before](browser:/invocations/ghdgurxw/artifacts/artifacts/hero-mobile-before.png)
- After: ![Mobile hero after](browser:/invocations/eteixjfv/artifacts/artifacts/hero-mobile.png)

### Mobile recipes
- Before: ![Mobile recipes before](browser:/invocations/ghdgurxw/artifacts/artifacts/recipes-mobile-before.png)
- After: ![Mobile recipes after](browser:/invocations/eteixjfv/artifacts/artifacts/recipes-mobile.png)

## Lighthouse (mobile)
- Attempted to run via `CHROME_PATH=/usr/bin/chromium-browser npx lighthouse …` but chromium snap is unavailable in the container (`Unable to connect to Chrome`).


------
https://chatgpt.com/codex/tasks/task_e_68db892643e48320b958f5af09c9d836