### PR TITLE
feat: launch dashboard and mini app experience

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,13 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run build

--- a/app/app/chat/page.tsx
+++ b/app/app/chat/page.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { FormEvent, useMemo, useState } from "react";
+import Card from "@/components/Card";
+import { showToast } from "@/lib/toast";
+import { trackEvent } from "@/lib/analytics";
+import clsx from "clsx";
+
+type Message = {
+  id: string;
+  role: "user" | "assistant";
+  text: string;
+  time: string;
+};
+
+const initialMessages: Message[] = [
+  {
+    id: "1",
+    role: "assistant",
+    text: "Здравствуйте! Чем сегодня помочь? Могу подсказать рецепт, разобрать документ или подсобрать идеи.",
+    time: "09:32",
+  },
+  {
+    id: "2",
+    role: "user",
+    text: "Привет! Нужен план письма клиенту, чтобы мягко перенести дедлайн.",
+    time: "09:33",
+  },
+  {
+    id: "3",
+    role: "assistant",
+    text: "Собрала структуру: 1) поблагодарить, 2) честно сказать о причине, 3) предложить новые сроки и бонус. Могу развернуть?",
+    time: "09:33",
+  },
+];
+
+const chips = [
+  "Сделай короче",
+  "Добавь конкретику",
+  "Списком",
+  "Попроси уточнения",
+  "На «ты»",
+];
+
+const formatActions = [
+  { id: "bold", label: "Жирный", symbol: "B" },
+  { id: "list", label: "Список", symbol: "•" },
+  { id: "quote", label: "Цитата", symbol: "❝" },
+];
+
+export default function ChatPage() {
+  const [messages, setMessages] = useState<Message[]>(initialMessages);
+  const [inputValue, setInputValue] = useState("Нужно перенести дедлайн на пятницу, сохранив доверие.");
+  const [isSending, setIsSending] = useState(false);
+
+  const lastMessages = useMemo(() => messages.slice(-6), [messages]);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const value = inputValue.trim();
+    if (!value) return;
+
+    setIsSending(true);
+    const newMessage: Message = {
+      id: crypto.randomUUID(),
+      role: "user",
+      text: value,
+      time: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),
+    };
+    setMessages((prev) => [...prev, newMessage]);
+    setInputValue("");
+    showToast("Сообщение отправлено");
+    trackEvent("chat_send", { length: value.length });
+
+    window.setTimeout(() => {
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: crypto.randomUUID(),
+          role: "assistant",
+          text: "Записала. Подготовлю письмо на мягкий перенос и добавлю два варианта бонуса.",
+          time: new Date().toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }),
+        },
+      ]);
+      setIsSending(false);
+    }, 800);
+  };
+
+  const handleChip = (chip: string) => {
+    setInputValue((prev) => (prev ? `${prev}. ${chip}` : chip));
+  };
+
+  const handleFormat = (id: string) => {
+    showToast(`Применили формат «${id}»`);
+  };
+
+  return (
+    <div className="space-y-8">
+      <header className="scroll-reveal space-y-2">
+        <h1 className="text-3xl font-semibold text-text">Чат</h1>
+        <p className="text-sm text-muted">Задавайте вопросы простыми словами, мы уточним и подготовим готовый ответ.</p>
+      </header>
+
+      <section className="scroll-reveal space-y-4">
+        <div className="flex flex-wrap items-center gap-2">
+          {chips.map((chip) => (
+            <button
+              key={chip}
+              type="button"
+              onClick={() => handleChip(chip)}
+              className="rounded-full border border-neutral-200/70 bg-white/95 px-3 py-1 text-sm font-semibold text-muted transition hover:text-text"
+            >
+              {chip}
+            </button>
+          ))}
+        </div>
+        <Card className="flex h-[420px] flex-col gap-4 overflow-hidden bg-white/95">
+          <div className="flex-1 space-y-3 overflow-y-auto rounded-[14px] bg-neutral-50/70 p-4">
+            {lastMessages.map((message) => (
+              <div
+                key={message.id}
+                className={clsx(
+                  "max-w-xl rounded-2xl px-4 py-3 text-sm leading-relaxed",
+                  message.role === "assistant"
+                    ? "bg-white text-text shadow-soft"
+                    : "ml-auto bg-primary text-white"
+                )}
+                aria-label={message.role === "assistant" ? "Сообщение ассистента" : "Ваше сообщение"}
+              >
+                <p>{message.text}</p>
+                <span className="mt-2 block text-xs opacity-70">{message.time}</span>
+              </div>
+            ))}
+          </div>
+          <form onSubmit={handleSubmit} className="space-y-3">
+            <div className="flex items-center gap-2">
+              {formatActions.map((action) => (
+                <button
+                  key={action.id}
+                  type="button"
+                  onClick={() => handleFormat(action.id)}
+                  className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-neutral-200/70 text-sm font-semibold text-muted transition hover:text-text"
+                  aria-label={action.label}
+                >
+                  {action.symbol}
+                </button>
+              ))}
+              <div className="ml-auto flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => showToast("Голосовой ввод скоро будет доступен")}
+                  className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-neutral-200/70 text-muted transition hover:text-text"
+                  aria-label="Голосовой ввод"
+                >
+                  🎙️
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    showToast("Загрузка файла");
+                    trackEvent("file_upload", { source: "chat" });
+                  }}
+                  className="inline-flex h-9 w-9 items-center justify-center rounded-xl border border-neutral-200/70 text-muted transition hover:text-text"
+                  aria-label="Прикрепить файл"
+                >
+                  📎
+                </button>
+              </div>
+            </div>
+            <textarea
+              value={inputValue}
+              onChange={(event) => setInputValue(event.target.value)}
+              placeholder="Опишите, что нужно сделать"
+              rows={3}
+              className="w-full rounded-2xl border border-neutral-200/70 bg-white/95 px-4 py-3 text-sm text-text placeholder:text-muted focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
+            />
+            <div className="flex items-center justify-between">
+              <span className="text-xs text-muted">Ответ придёт за пару секунд. Можно задавать follow-up.</span>
+              <button
+                type="submit"
+                disabled={isSending}
+                className="inline-flex items-center gap-2 rounded-xl bg-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-primary/90 disabled:opacity-60"
+              >
+                Отправить
+                <span aria-hidden>↗</span>
+              </button>
+            </div>
+          </form>
+        </Card>
+      </section>
+    </div>
+  );
+}

--- a/app/app/files/page.tsx
+++ b/app/app/files/page.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useState } from "react";
+import Card from "@/components/Card";
+import { showToast } from "@/lib/toast";
+import { trackEvent } from "@/lib/analytics";
+import clsx from "clsx";
+
+type FileItem = {
+  id: string;
+  name: string;
+  type: "doc" | "table" | "audio";
+  size: string;
+  updatedAt: string;
+  owner: string;
+  pinned?: boolean;
+};
+
+const files: FileItem[] = [
+  { id: "1", name: "Коммерческое предложение.pdf", type: "doc", size: "1.2 МБ", updatedAt: "5 мин назад", owner: "Вы", pinned: true },
+  { id: "2", name: "Сводка затрат.xlsx", type: "table", size: "480 КБ", updatedAt: "Вчера", owner: "Анна" },
+  { id: "3", name: "Расшифровка звонка.m4a", type: "audio", size: "2.1 МБ", updatedAt: "3 дня назад", owner: "Вы" },
+];
+
+const typeLabels: Record<FileItem["type"], string> = {
+  doc: "Документ",
+  table: "Таблица",
+  audio: "Аудио",
+};
+
+export default function FilesPage() {
+  const [view, setView] = useState<"grid" | "list">("grid");
+
+  const handleUpload = () => {
+    showToast("Выберите файл для загрузки");
+    trackEvent("file_upload", { source: "files" });
+  };
+
+  return (
+    <div className="space-y-8">
+      <header className="scroll-reveal space-y-3">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-semibold text-text">Файлы</h1>
+            <p className="text-sm text-muted">Загружайте документы, таблицы и аудио — мы расшифруем и подскажем действия.</p>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={handleUpload}
+              className="inline-flex items-center gap-2 rounded-xl bg-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-primary/90"
+            >
+              Загрузить файл
+            </button>
+            <div className="rounded-xl border border-neutral-200/70 p-1 text-sm font-semibold text-muted">
+              <button
+                type="button"
+                onClick={() => setView("grid")}
+                className={clsx(
+                  "rounded-lg px-3 py-1",
+                  view === "grid" ? "bg-white text-text shadow-soft" : "hover:text-text"
+                )}
+              >
+                Плитка
+              </button>
+              <button
+                type="button"
+                onClick={() => setView("list")}
+                className={clsx(
+                  "rounded-lg px-3 py-1",
+                  view === "list" ? "bg-white text-text shadow-soft" : "hover:text-text"
+                )}
+              >
+                Таблица
+              </button>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      {view === "grid" ? (
+        <section className="scroll-reveal grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+          {files.map((file) => (
+            <Card key={file.id} className="flex flex-col gap-3">
+              <div className="flex items-center justify-between">
+                <span className="inline-flex items-center gap-2 text-sm font-semibold text-text">
+                  {file.type === "doc" && "📄"}
+                  {file.type === "table" && "📊"}
+                  {file.type === "audio" && "🎧"}
+                  {file.name}
+                </span>
+                {file.pinned && (
+                  <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-primary">
+                    Закреплено
+                  </span>
+                )}
+              </div>
+              <p className="text-sm text-muted">{typeLabels[file.type]} · {file.size}</p>
+              <div className="mt-auto flex items-center justify-between text-xs text-muted">
+                <span>{file.updatedAt}</span>
+                <span>{file.owner}</span>
+              </div>
+              <div className="flex items-center justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={() => showToast("Открываем файл")}
+                  className="inline-flex items-center gap-1 rounded-xl border border-neutral-200/70 px-3 py-1.5 text-xs font-semibold text-muted transition hover:text-text"
+                >
+                  Открыть
+                </button>
+                <button
+                  type="button"
+                  onClick={() => showToast("Поделились ссылкой")}
+                  className="inline-flex items-center gap-1 rounded-xl border border-neutral-200/70 px-3 py-1.5 text-xs font-semibold text-muted transition hover:text-text"
+                >
+                  Поделиться
+                </button>
+              </div>
+            </Card>
+          ))}
+        </section>
+      ) : (
+        <section className="scroll-reveal overflow-hidden rounded-3xl border border-neutral-200/70 bg-white/95 shadow-soft">
+          <table className="min-w-full divide-y divide-neutral-200/70 text-left text-sm">
+            <thead className="bg-neutral-50/80 text-xs uppercase tracking-wide text-muted">
+              <tr>
+                <th scope="col" className="px-6 py-3 font-semibold">Файл</th>
+                <th scope="col" className="px-6 py-3 font-semibold">Тип</th>
+                <th scope="col" className="px-6 py-3 font-semibold">Размер</th>
+                <th scope="col" className="px-6 py-3 font-semibold">Обновлено</th>
+                <th scope="col" className="px-6 py-3 font-semibold">Владелец</th>
+                <th scope="col" className="px-6 py-3 text-right font-semibold">Действия</th>
+              </tr>
+            </thead>
+            <tbody>
+              {files.map((file) => (
+                <tr key={`row-${file.id}`} className="border-t border-neutral-200/70">
+                  <td className="px-6 py-4 text-sm font-semibold text-text">{file.name}</td>
+                  <td className="px-6 py-4 text-sm text-muted">{typeLabels[file.type]}</td>
+                  <td className="px-6 py-4 text-sm text-muted">{file.size}</td>
+                  <td className="px-6 py-4 text-sm text-muted">{file.updatedAt}</td>
+                  <td className="px-6 py-4 text-sm text-muted">{file.owner}</td>
+                  <td className="px-6 py-4 text-right text-sm">
+                    <button
+                      type="button"
+                      onClick={() => showToast("Открываем файл")}
+                      className="rounded-xl border border-neutral-200/70 px-3 py-1.5 text-xs font-semibold text-muted transition hover:text-text"
+                    >
+                      Открыть
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/app/app/layout.tsx
+++ b/app/app/layout.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import { ReactNode } from "react";
+import { usePathname } from "next/navigation";
+import AppShell from "@/components/app/AppShell";
+
+export default function AppLayout({ children }: { children: ReactNode }) {
+  const pathname = usePathname() ?? "/app";
+  return <AppShell activeRoute={pathname}>{children}</AppShell>;
+}

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -1,0 +1,319 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import Card from "@/components/Card";
+import { showToast } from "@/lib/toast";
+import { trackEvent } from "@/lib/analytics";
+
+type DashboardResult = {
+  id: string;
+  title: string;
+  snippet: string;
+  updatedAt: string;
+  pinned: boolean;
+  type: "recipe" | "chat" | "file";
+};
+
+const quickActions = [
+  {
+    id: "recipe",
+    title: "Новый рецепт",
+    description: "Подберите готовую инструкцию под задачу",
+    hint: "2 мин",
+    href: "/app/recipes",
+  },
+  {
+    id: "chat",
+    title: "Открыть чат",
+    description: "Спросите своими словами — ответим просто",
+    hint: "Через 5 сек",
+    href: "/app/chat",
+  },
+  {
+    id: "file",
+    title: "Загрузить файл",
+    description: "Документы, таблицы и презентации",
+    hint: "До 20 МБ",
+    href: "/app/files",
+  },
+];
+
+const initialResults: DashboardResult[] = [
+  {
+    id: "1",
+    title: "План урока: энергия и заряд",
+    snippet: "Вступление, объяснение через аналогии и задания на закрепление...",
+    updatedAt: "5 минут назад",
+    pinned: true,
+    type: "recipe",
+  },
+  {
+    id: "2",
+    title: "Письмо клиенту: перенос встреч",
+    snippet: "Добрый день! Понимаем, что сроки сдвинулись. Предлагаю два окна...",
+    updatedAt: "18 минут назад",
+    pinned: false,
+    type: "chat",
+  },
+  {
+    id: "3",
+    title: "Резюме разговора с командой",
+    snippet: "Собрали задачи, уточнили сроки и добавили follow-up на понедельник...",
+    updatedAt: "Вчера",
+    pinned: true,
+    type: "chat",
+  },
+  {
+    id: "4",
+    title: "Разбор договора поставки",
+    snippet: "Основные риски: пункт 4.2, уточнить ответственность за доставку...",
+    updatedAt: "2 дня назад",
+    pinned: false,
+    type: "file",
+  },
+];
+
+const typeLabels: Record<DashboardResult["type"], string> = {
+  recipe: "Рецепт",
+  chat: "Чат",
+  file: "Файл",
+};
+
+export default function DashboardPage() {
+  const router = useRouter();
+  const [results, setResults] = useState(initialResults);
+
+  const pinnedResults = useMemo(() => results.filter((result) => result.pinned), [results]);
+  const recentResults = useMemo(() => results.filter((result) => !result.pinned), [results]);
+
+  const handleQuickAction = (href: string) => {
+    if (href.includes("/recipes")) {
+      trackEvent("recipe_launch", { source: "dashboard" });
+    } else if (href.includes("/chat")) {
+      trackEvent("chat_send", { source: "dashboard" });
+    } else if (href.includes("/files")) {
+      trackEvent("file_upload", { source: "dashboard" });
+    }
+    router.push(href);
+  };
+
+  const handleTogglePin = (id: string) => {
+    setResults((items) =>
+      items.map((item) => (item.id === id ? { ...item, pinned: !item.pinned } : item))
+    );
+    showToast("Обновили закрепление");
+  };
+
+  const handleDelete = (id: string) => {
+    setResults((items) => items.filter((item) => item.id !== id));
+    showToast("Удалено");
+  };
+
+  const handleCopy = (id: string) => {
+    const item = results.find((result) => result.id === id);
+    if (!item) return;
+    showToast("Скопировали в буфер обмена");
+  };
+
+  const handleShare = () => {
+    showToast("Ссылка скопирована");
+  };
+
+  return (
+    <div className="space-y-10 lg:space-y-12">
+      <section className="scroll-reveal">
+        <div className="flex flex-col gap-2">
+          <h1 className="text-3xl font-semibold text-text">Домашняя</h1>
+          <p className="text-sm text-muted">
+            Начните с быстрого действия, посмотрите последние ответы или обновите тариф.
+          </p>
+        </div>
+        <div className="mt-6 grid gap-3 sm:grid-cols-3">
+          {quickActions.map((action) => (
+            <button
+              key={action.id}
+              type="button"
+              onClick={() => handleQuickAction(action.href)}
+              className="group rounded-2xl border border-neutral-200/70 bg-white/95 px-5 py-5 text-left shadow-soft transition hover:-translate-y-0.5 hover:shadow-soft-lg"
+            >
+              <span className="inline-flex items-center rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold text-primary">
+                {action.hint}
+              </span>
+              <h2 className="mt-4 text-lg font-semibold text-text">{action.title}</h2>
+              <p className="mt-2 text-sm text-muted">{action.description}</p>
+              <span className="mt-4 inline-flex items-center text-sm font-semibold text-primary">
+                Перейти
+                <span aria-hidden className="ml-1 transition group-hover:translate-x-0.5">
+                  →
+                </span>
+              </span>
+            </button>
+          ))}
+        </div>
+      </section>
+
+      <section className="scroll-reveal space-y-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-text">Последние результаты</h2>
+            <p className="text-sm text-muted">Всё, что генерировали недавно — чаты, рецепты и файлы.</p>
+          </div>
+          <button
+            type="button"
+            onClick={() => showToast("Обновили ленту")}
+            className="hidden rounded-xl border border-neutral-200/70 px-4 py-2 text-sm font-semibold text-muted transition hover:text-text sm:inline-flex"
+          >
+            Обновить
+          </button>
+        </div>
+        <div className="grid gap-3 lg:grid-cols-2">
+          {recentResults.length === 0 && (
+            <Card className="col-span-full flex flex-col items-start gap-3">
+              <span className="rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold text-primary">Пока пусто</span>
+              <p className="text-lg font-semibold text-text">Здесь появятся свежие ответы</p>
+              <p className="text-sm text-muted">
+                Создайте рецепт, начните чат или загрузите файл, чтобы увидеть историю здесь.
+              </p>
+              <button
+                type="button"
+                onClick={() => handleQuickAction("/app/recipes")}
+                className="rounded-xl bg-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-primary/90"
+              >
+                Создать первый рецепт
+              </button>
+            </Card>
+          )}
+          {recentResults.map((result) => (
+            <Card key={result.id} className="flex flex-col gap-4">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <span className="inline-flex items-center rounded-full bg-neutral-100 px-3 py-1 text-xs font-semibold text-muted">
+                    {typeLabels[result.type]}
+                  </span>
+                  <h3 className="mt-3 text-lg font-semibold text-text">{result.title}</h3>
+                  <p className="mt-2 text-sm text-muted">{result.snippet}</p>
+                </div>
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => handleCopy(result.id)}
+                    className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-neutral-200/70 text-muted transition hover:text-text"
+                    aria-label="Скопировать"
+                  >
+                    ⧉
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleShare}
+                    className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-neutral-200/70 text-muted transition hover:text-text"
+                    aria-label="Поделиться"
+                  >
+                    ↗
+                  </button>
+                </div>
+              </div>
+              <div className="flex items-center justify-between text-xs text-muted">
+                <span>{result.updatedAt}</span>
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() => handleTogglePin(result.id)}
+                    className="inline-flex items-center gap-1 rounded-xl border border-neutral-200/70 px-3 py-1.5 text-xs font-semibold text-muted transition hover:text-text"
+                  >
+                    {result.pinned ? "Открепить" : "Закрепить"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleDelete(result.id)}
+                    className="inline-flex items-center gap-1 rounded-xl border border-neutral-200/70 px-3 py-1.5 text-xs font-semibold text-muted transition hover:text-error"
+                  >
+                    Удалить
+                  </button>
+                </div>
+              </div>
+            </Card>
+          ))}
+        </div>
+      </section>
+
+      <section className="scroll-reveal space-y-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-xl font-semibold text-text">Закреплённые</h2>
+            <p className="text-sm text-muted">То, к чему вы часто возвращаетесь.</p>
+          </div>
+        </div>
+        {pinnedResults.length === 0 ? (
+          <Card className="flex flex-col items-start gap-3">
+            <span className="rounded-full bg-neutral-100 px-3 py-1 text-xs font-semibold text-muted">Пока пусто</span>
+            <p className="text-lg font-semibold text-text">Закрепите важные результаты</p>
+            <p className="text-sm text-muted">Нажмите «Закрепить» у результата, чтобы видеть его здесь.</p>
+          </Card>
+        ) : (
+          <div className="grid gap-3 md:grid-cols-2">
+            {pinnedResults.map((result) => (
+              <Card key={`pinned-${result.id}`} className="flex flex-col gap-3">
+                <div className="flex items-center justify-between">
+                  <span className="rounded-full bg-primary/10 px-3 py-1 text-xs font-semibold text-primary">Закреплено</span>
+                  <span className="text-xs text-muted">{result.updatedAt}</span>
+                </div>
+                <h3 className="text-lg font-semibold text-text">{result.title}</h3>
+                <p className="text-sm text-muted">{result.snippet}</p>
+                <div className="flex items-center justify-end gap-2">
+                  <button
+                    type="button"
+                    onClick={() => handleQuickAction(result.type === "chat" ? "/app/chat" : "/app/recipes")}
+                    className="inline-flex items-center gap-1 rounded-xl border border-neutral-200/70 px-3 py-1.5 text-xs font-semibold text-muted transition hover:text-text"
+                  >
+                    Открыть
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleTogglePin(result.id)}
+                    className="inline-flex items-center gap-1 rounded-xl border border-neutral-200/70 px-3 py-1.5 text-xs font-semibold text-muted transition hover:text-text"
+                  >
+                    Открепить
+                  </button>
+                </div>
+              </Card>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section className="scroll-reveal">
+        <Card className="flex flex-col gap-4 bg-gradient-to-r from-primary/8 via-primary/6 to-primary/10">
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <div>
+              <h2 className="text-xl font-semibold text-text">Лимиты и тариф</h2>
+              <p className="mt-1 text-sm text-muted">Вы израсходовали 24 из 50 генераций. Продлите доступ, чтобы не останавливаться.</p>
+            </div>
+            <button
+              type="button"
+              onClick={() => {
+                trackEvent("plan_upgrade", { source: "dashboard_limits" });
+                showToast("Переходим к тарифам");
+              }}
+              className="inline-flex items-center justify-center rounded-xl bg-primary px-5 py-2 text-sm font-semibold text-white transition hover:bg-primary/90"
+            >
+              Обновить
+            </button>
+          </div>
+          <div className="space-y-2">
+            <div className="flex items-center justify-between text-xs font-semibold text-muted">
+              <span>Использовано</span>
+              <span>24 / 50</span>
+            </div>
+            <div className="h-2 rounded-full bg-white/60">
+              <div className="h-full rounded-full bg-primary" style={{ width: "48%" }} />
+            </div>
+            <p className="text-xs text-muted">
+              Бесплатный план. Обновление до «Команды» добавит ещё 200 генераций, общую папку и контроль доступа.
+            </p>
+          </div>
+        </Card>
+      </section>
+    </div>
+  );
+}

--- a/app/app/recipes/page.tsx
+++ b/app/app/recipes/page.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import RecipeCard from "@/components/RecipeCard";
+import { recipeTabs, recipes, type Recipe, type RecipeCategory } from "@/lib/data";
+import { showToast } from "@/lib/toast";
+import { trackEvent } from "@/lib/analytics";
+import clsx from "clsx";
+
+const allTabs: (RecipeCategory | "Все")[] = ["Все", ...recipeTabs.map((tab) => tab.id)];
+
+export default function RecipesPage() {
+  const [activeTab, setActiveTab] = useState<RecipeCategory | "Все">("Все");
+  const [search, setSearch] = useState("");
+  const [onlyPinned, setOnlyPinned] = useState(false);
+  const [pinned, setPinned] = useState<string[]>(["calm-hoa-post", "lesson-plan"]);
+
+  const filteredRecipes = useMemo(() => {
+    return recipes.filter((recipe) => {
+      const matchesTab = activeTab === "Все" || recipe.categories.includes(activeTab);
+      const matchesSearch = recipe.title.toLowerCase().includes(search.toLowerCase());
+      const matchesPinned = !onlyPinned || pinned.includes(recipe.id);
+      return matchesTab && matchesSearch && matchesPinned;
+    });
+  }, [activeTab, onlyPinned, pinned, search]);
+
+  const handleLaunch = (recipe: Recipe) => {
+    trackEvent("recipe_launch", { recipeId: recipe.id, tab: activeTab });
+    showToast(`Запускаем рецепт «${recipe.title}»`);
+  };
+
+  const handleTogglePin = (id: string) => {
+    setPinned((prev) =>
+      prev.includes(id) ? prev.filter((recipeId) => recipeId !== id) : [...prev, id]
+    );
+    showToast("Обновили закрепление рецепта");
+  };
+
+  return (
+    <div className="space-y-8">
+      <header className="scroll-reveal space-y-3">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-semibold text-text">Рецепты</h1>
+            <p className="text-sm text-muted">Готовые сценарии для типичных задач. Выберите пресет или ищите по названию.</p>
+          </div>
+          <div className="flex items-center gap-3">
+            <label className="relative flex items-center">
+              <span className="sr-only">Поиск рецептов</span>
+              <input
+                value={search}
+                onChange={(event) => setSearch(event.target.value)}
+                type="search"
+                placeholder="Найти рецепт"
+                className="w-full rounded-xl border border-neutral-200/70 bg-white/95 px-4 py-2 text-sm text-text placeholder:text-muted focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
+              />
+            </label>
+            <button
+              type="button"
+              onClick={() => setOnlyPinned((prev) => !prev)}
+              className={clsx(
+                "inline-flex items-center gap-2 rounded-xl border px-4 py-2 text-sm font-semibold transition",
+                onlyPinned
+                  ? "border-primary/50 bg-primary/10 text-primary"
+                  : "border-neutral-200/70 text-muted hover:text-text"
+              )}
+            >
+              <span aria-hidden>📌</span>
+              Закреплённые
+            </button>
+          </div>
+        </div>
+        <nav aria-label="Категории рецептов" className="flex flex-wrap gap-2">
+          {allTabs.map((tab) => (
+            <button
+              key={tab}
+              type="button"
+              onClick={() => setActiveTab(tab)}
+              className={clsx(
+                "rounded-full px-4 py-2 text-sm font-semibold transition",
+                tab === activeTab
+                  ? "bg-primary text-white shadow-soft"
+                  : "bg-white/80 text-muted hover:text-text"
+              )}
+            >
+              {tab}
+            </button>
+          ))}
+        </nav>
+      </header>
+
+      <section className="scroll-reveal">
+        {filteredRecipes.length === 0 ? (
+          <div className="rounded-3xl border border-neutral-200/70 bg-white/95 p-6 text-center shadow-soft">
+            <p className="text-lg font-semibold text-text">Не нашли подходящий рецепт</p>
+            <p className="mt-2 text-sm text-muted">Попробуйте другую категорию или отключите фильтр закреплённых.</p>
+          </div>
+        ) : (
+          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+            {filteredRecipes.map((recipe) => (
+              <div key={recipe.id} className="relative">
+                <div className="absolute right-5 top-5 z-10">
+                  <button
+                    type="button"
+                    onClick={() => handleTogglePin(recipe.id)}
+                    className={clsx(
+                      "inline-flex h-9 w-9 items-center justify-center rounded-full border text-sm font-semibold transition",
+                      pinned.includes(recipe.id)
+                        ? "border-primary/40 bg-primary/10 text-primary"
+                        : "border-neutral-200/70 bg-white/90 text-muted hover:text-text"
+                    )}
+                    aria-label={pinned.includes(recipe.id) ? "Убрать из закреплённых" : "Закрепить рецепт"}
+                  >
+                    📌
+                  </button>
+                </div>
+                <RecipeCard
+                  recipe={recipe}
+                  tab={activeTab === "Все" ? "Популярные" : activeTab}
+                  onLaunch={(item) => handleLaunch(item)}
+                />
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/app/app/settings/page.tsx
+++ b/app/app/settings/page.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useState } from "react";
+import Card from "@/components/Card";
+import { useAppStore } from "@/lib/store";
+import { showToast } from "@/lib/toast";
+import { trackEvent } from "@/lib/analytics";
+import clsx from "clsx";
+
+export default function SettingsPage() {
+  const {
+    preferences: { autoModel },
+    setAutoModel,
+  } = useAppStore();
+  const [privateMode, setPrivateMode] = useState(true);
+  const [historyRetention, setHistoryRetention] = useState("30");
+
+  const handleTogglePrivate = () => {
+    setPrivateMode((prev) => !prev);
+    showToast("Обновили приватный режим");
+    trackEvent("privacy_change", { setting: "private_mode", value: !privateMode });
+  };
+
+  const handleRetentionChange = (value: string) => {
+    setHistoryRetention(value);
+    showToast("Срок хранения обновлён");
+    trackEvent("privacy_change", { setting: "retention_days", value });
+  };
+
+  const handlePlanUpgrade = () => {
+    showToast("Переключаем на оплату");
+    trackEvent("plan_upgrade", { source: "settings" });
+  };
+
+  return (
+    <div className="space-y-8">
+      <header className="scroll-reveal space-y-2">
+        <h1 className="text-3xl font-semibold text-text">Настройки</h1>
+        <p className="text-sm text-muted">Управляйте приватностью, сроком хранения и подпиской.</p>
+      </header>
+
+      <section className="scroll-reveal grid gap-4 md:grid-cols-2">
+        <Card className="flex flex-col gap-4">
+          <div>
+            <h2 className="text-xl font-semibold text-text">Приватность</h2>
+            <p className="text-sm text-muted">Запросы шифруются. Можно отключить сохранение истории.</p>
+          </div>
+          <div className="flex items-center justify-between rounded-2xl border border-neutral-200/70 bg-neutral-50/80 px-4 py-3">
+            <div>
+              <p className="text-sm font-semibold text-text">Приватный режим</p>
+              <p className="text-xs text-muted">Не сохраняем запросы после завершения сессии.</p>
+            </div>
+            <button
+              type="button"
+              onClick={handleTogglePrivate}
+              className="inline-flex items-center gap-2 rounded-full border border-neutral-200/70 bg-white/95 px-3 py-1 text-sm font-semibold text-text"
+              aria-pressed={privateMode}
+            >
+              <span
+                className={clsx(
+                  "inline-flex h-5 w-10 items-center rounded-full",
+                  privateMode ? "bg-primary/30" : "bg-neutral-200"
+                )}
+              >
+                <span
+                  className={clsx(
+                    "ml-0.5 inline-flex h-4 w-4 items-center justify-center rounded-full bg-white shadow-soft transition",
+                    privateMode ? "translate-x-5" : "translate-x-0"
+                  )}
+                />
+              </span>
+              {privateMode ? "Включён" : "Выключен"}
+            </button>
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-semibold text-text" htmlFor="history-retention">
+              Срок хранения истории
+            </label>
+            <select
+              id="history-retention"
+              value={historyRetention}
+              onChange={(event) => handleRetentionChange(event.target.value)}
+              className="w-full rounded-xl border border-neutral-200/70 bg-white/95 px-4 py-2 text-sm font-semibold text-text focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
+            >
+              <option value="7">7 дней</option>
+              <option value="30">30 дней</option>
+              <option value="90">90 дней</option>
+            </select>
+          </div>
+        </Card>
+
+        <Card className="flex flex-col gap-4">
+          <div>
+            <h2 className="text-xl font-semibold text-text">Автовыбор модели</h2>
+            <p className="text-sm text-muted">Мы сами подбираем подходящую модель под запрос.</p>
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              setAutoModel(!autoModel);
+              showToast(autoModel ? "Автовыбор отключён" : "Автовыбор включён");
+              trackEvent("privacy_change", { setting: "auto_model", value: !autoModel });
+            }}
+            className={clsx(
+              "inline-flex items-center gap-2 rounded-full border border-neutral-200/70 bg-white/95 px-3 py-1 text-sm font-semibold text-text",
+              autoModel && "ring-2 ring-primary/30"
+            )}
+            aria-pressed={autoModel}
+          >
+            <span
+              className={clsx(
+                "inline-flex h-5 w-10 items-center rounded-full",
+                autoModel ? "bg-primary/30" : "bg-neutral-200"
+              )}
+            >
+              <span
+                className={clsx(
+                  "ml-0.5 inline-flex h-4 w-4 items-center justify-center rounded-full bg-white shadow-soft transition",
+                  autoModel ? "translate-x-5" : "translate-x-0"
+                )}
+              />
+            </span>
+            {autoModel ? "Включён" : "Выключен"}
+          </button>
+          <p className="text-xs text-muted">Можно переключить в любой момент прямо из чата или рецептов.</p>
+        </Card>
+      </section>
+
+      <section className="scroll-reveal">
+        <Card className="flex flex-col gap-4 bg-gradient-to-r from-primary/8 via-primary/6 to-primary/10">
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <div>
+              <h2 className="text-xl font-semibold text-text">Тариф «Команда»</h2>
+              <p className="mt-1 text-sm text-muted">200 генераций в день, общие папки, до 5 участников, приоритетная поддержка.</p>
+            </div>
+            <button
+              type="button"
+              onClick={handlePlanUpgrade}
+              className="inline-flex items-center justify-center rounded-xl bg-primary px-5 py-2 text-sm font-semibold text-white transition hover:bg-primary/90"
+            >
+              Обновить до 699 ₽/мес
+            </button>
+          </div>
+          <p className="text-xs text-muted">Отменить можно в любой момент. Напомним за три дня до списания.</p>
+        </Card>
+      </section>
+    </div>
+  );
+}

--- a/app/app/team/page.tsx
+++ b/app/app/team/page.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useState } from "react";
+import Card from "@/components/Card";
+import { showToast } from "@/lib/toast";
+
+const roles = ["Владелец", "Редактор", "Просмотр"] as const;
+
+type Role = (typeof roles)[number];
+
+type Member = {
+  id: string;
+  name: string;
+  email: string;
+  role: Role;
+};
+
+const initialMembers: Member[] = [
+  { id: "1", name: "Вы", email: "you@prostoii.ru", role: "Владелец" },
+  { id: "2", name: "Анна Морозова", email: "anna@example.com", role: "Редактор" },
+  { id: "3", name: "Илья Петров", email: "ilya@example.com", role: "Просмотр" },
+];
+
+export default function TeamPage() {
+  const [members, setMembers] = useState<Member[]>(initialMembers);
+  const inviteLink = "https://t.me/prostoii_bot?start=team";
+
+  const handleRoleChange = (id: string, role: Role) => {
+    setMembers((prev) => prev.map((member) => (member.id === id ? { ...member, role } : member)));
+    showToast("Роль обновлена");
+  };
+
+  const handleCopy = () => {
+    showToast("Ссылка скопирована");
+  };
+
+  const handleRemove = (id: string) => {
+    setMembers((prev) => prev.filter((member) => member.id !== id));
+    showToast("Участник удалён");
+  };
+
+  return (
+    <div className="space-y-8">
+      <header className="scroll-reveal space-y-2">
+        <h1 className="text-3xl font-semibold text-text">Команда</h1>
+        <p className="text-sm text-muted">Приглашайте коллег, настраивайте роли и делитесь избранными рецептами.</p>
+      </header>
+
+      <section className="scroll-reveal grid gap-4 md:grid-cols-[2fr_1fr]">
+        <Card className="flex flex-col gap-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-xl font-semibold text-text">Участники</h2>
+              <p className="text-sm text-muted">Управляйте доступами и ролями.</p>
+            </div>
+            <button
+              type="button"
+              onClick={handleCopy}
+              className="rounded-xl border border-neutral-200/70 px-4 py-2 text-sm font-semibold text-muted transition hover:text-text"
+            >
+              Скопировать инвайт
+            </button>
+          </div>
+          <ul className="space-y-3">
+            {members.map((member) => (
+              <li key={member.id} className="flex flex-wrap items-center gap-3 rounded-2xl border border-neutral-200/70 bg-neutral-50/70 px-4 py-3">
+                <div className="flex min-w-[180px] flex-col">
+                  <span className="text-sm font-semibold text-text">{member.name}</span>
+                  <span className="text-xs text-muted">{member.email}</span>
+                </div>
+                <select
+                  value={member.role}
+                  onChange={(event) => handleRoleChange(member.id, event.target.value as Role)}
+                  className="rounded-xl border border-neutral-200/70 bg-white/90 px-3 py-2 text-sm font-semibold text-text focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
+                  aria-label={`Роль для ${member.name}`}
+                >
+                  {roles.map((role) => (
+                    <option key={role} value={role}>
+                      {role}
+                    </option>
+                  ))}
+                </select>
+                {member.id !== "1" && (
+                  <button
+                    type="button"
+                    onClick={() => handleRemove(member.id)}
+                    className="ml-auto inline-flex items-center rounded-xl border border-neutral-200/70 px-3 py-2 text-xs font-semibold text-muted transition hover:text-error"
+                  >
+                    Удалить
+                  </button>
+                )}
+              </li>
+            ))}
+          </ul>
+        </Card>
+        <Card className="flex flex-col gap-4 bg-neutral-50/80">
+          <div>
+            <h2 className="text-lg font-semibold text-text">Инвайт-ссылка</h2>
+            <p className="mt-1 text-sm text-muted">Отправьте коллегам или поделитесь в чате. Лимит — 5 активных приглашений.</p>
+          </div>
+          <div className="rounded-2xl border border-dashed border-neutral-200/70 bg-white/95 px-4 py-3 text-sm text-text">
+            {inviteLink}
+          </div>
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="inline-flex items-center justify-center rounded-xl bg-primary px-4 py-2 text-sm font-semibold text-white transition hover:bg-primary/90"
+          >
+            Скопировать ссылку
+          </button>
+          <p className="text-xs text-muted">Можно отключить доступ в любой момент.</p>
+        </Card>
+      </section>
+    </div>
+  );
+}

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import Link from "next/link";
+
+export default function Error({ error }: { error: Error }) {
+  return (
+    <main className="container-soft py-16 text-center">
+      <h1 className="text-3xl font-semibold text-text">Что-то пошло не так</h1>
+      <p className="mt-3 text-muted">Мы уже разбираемся. Попробуйте обновить страницу.</p>
+      <pre className="mt-4 text-xs text-muted/80">{error.message}</pre>
+      <Link href="/" className="mt-6 inline-block underline text-primary">
+        На главную →
+      </Link>
+    </main>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -23,11 +23,13 @@
   --surface: #ffffff;
   --muted: #f6f7f9;
   --muted-border: rgba(15, 18, 34, 0.08);
-  --muted-text: rgba(15, 18, 34, 0.6);
+  --muted-text: rgba(15, 18, 34, 0.68);
   --success: #10b981;
   --warning: #f59e0b;
   --error: #dc2626;
   --white: #ffffff;
+  --shadow-soft: 0 16px 40px -24px rgba(15, 18, 34, 0.16);
+  --shadow-soft-lg: 0 24px 56px -28px rgba(15, 18, 34, 0.2);
 }
 
 html,
@@ -69,6 +71,28 @@ body {
   background-color: var(--primary);
 }
 
+.bg-surface {
+  background-color: var(--surface);
+}
+
+.shadow-soft {
+  box-shadow: var(--shadow-soft);
+}
+
+.shadow-soft-lg {
+  box-shadow: var(--shadow-soft-lg);
+}
+
+.hover\:shadow-soft-lg:hover {
+  box-shadow: var(--shadow-soft-lg);
+}
+
+.section-divider {
+  height: 1px;
+  width: 100%;
+  background: linear-gradient(90deg, transparent, rgba(15, 18, 34, 0.08), transparent);
+}
+
 .container-soft {
   max-width: 1200px;
   margin: 0 auto;
@@ -105,6 +129,32 @@ body {
 .toast--visible {
   opacity: 1;
   transform: translate(-50%, -4px);
+}
+
+.scroll-reveal {
+  opacity: 0;
+  transform: translateY(24px);
+  animation: reveal 0.7s ease forwards;
+}
+
+@keyframes reveal {
+  from {
+    opacity: 0;
+    transform: translateY(24px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .scroll-reveal {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
 }
 
 .hero-surface::before {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -85,7 +85,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               </Button>
             </div>
           </div>
-          <div id="toast" className="toast" aria-live="polite" aria-atomic="true" />
+          <div id="toast" className="toast" role="status" aria-live="polite" aria-atomic="true" />
         </AppStateProvider>
         <Script
           id="prostoii-ld"

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import Script from "next/script";
+import { useRouter } from "next/navigation";
+import { useAppStore } from "@/lib/store";
+import { showToast } from "@/lib/toast";
+import { trackEvent } from "@/lib/analytics";
+
+const TELEGRAM_BOT = "prostoii_bot";
+
+type TelegramAuthPayload = {
+  id: number;
+  first_name: string;
+  last_name?: string;
+  username?: string;
+  photo_url?: string;
+  hash: string;
+  auth_date: string;
+};
+
+declare global {
+  interface Window {
+    __prostoiiTelegramAuth?: (user: TelegramAuthPayload) => void;
+  }
+}
+
+export default function LoginPage() {
+  const router = useRouter();
+  const { auth, setUser } = useAppStore();
+  const { onboardingDone } = auth;
+
+  useEffect(() => {
+    window.__prostoiiTelegramAuth = (user) => {
+      setUser({
+        id: String(user.id),
+        name: [user.first_name, user.last_name].filter(Boolean).join(" ") || user.first_name,
+        username: user.username,
+        avatarUrl: user.photo_url,
+      });
+      trackEvent("login_success", { user_id: user.id });
+      showToast("Готово. Мы никому ничего не публикуем.");
+      const nextRoute = onboardingDone ? "/app" : "/onboarding";
+      router.push(nextRoute);
+    };
+
+    return () => {
+      delete window.__prostoiiTelegramAuth;
+    };
+  }, [onboardingDone, router, setUser]);
+
+  return (
+    <main className="min-h-screen bg-surface">
+      <div className="mx-auto flex min-h-screen w-full max-w-3xl flex-col justify-center px-4 py-12 sm:px-6">
+        <div className="rounded-3xl border border-neutral-200/70 bg-white/95 p-8 shadow-soft-lg">
+          <div className="mb-8 text-center">
+            <p className="text-xs font-semibold uppercase tracking-[0.32em] text-primary">ПростоИИ</p>
+            <h1 className="mt-3 text-3xl font-semibold text-text">Войдите через Telegram</h1>
+            <p className="mt-3 text-sm text-muted">
+              Мы используем Telegram только для авторизации. Ничего не публикуем и не пишем вашим контактам.
+            </p>
+          </div>
+          <div className="flex flex-col gap-4">
+            <div className="flex items-center justify-center">
+              <div id="telegram-login" className="flex justify-center">
+                <Script
+                  src="https://telegram.org/js/telegram-widget.js?22"
+                  data-telegram-login={TELEGRAM_BOT}
+                  data-size="large"
+                  data-userpic="false"
+                  data-request-access="write"
+                  data-onauth="window.__prostoiiTelegramAuth && window.__prostoiiTelegramAuth(user)"
+                  strategy="afterInteractive"
+                />
+              </div>
+            </div>
+            <Link
+              href={`https://t.me/${TELEGRAM_BOT}?start=webapp`}
+              className="inline-flex items-center justify-center gap-2 rounded-2xl bg-primary px-4 py-3 text-sm font-semibold text-white transition hover:bg-primary/90"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Открыть в Telegram
+              <span aria-hidden>↗</span>
+            </Link>
+            <p className="text-center text-xs text-muted">
+              Если кнопка выше не работает, откройте @prostoii_bot и нажмите «Открыть веб-версию».
+            </p>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/mini/app/chat/page.tsx
+++ b/app/mini/app/chat/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/app/app/chat/page";

--- a/app/mini/app/files/page.tsx
+++ b/app/mini/app/files/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/app/app/files/page";

--- a/app/mini/app/layout.tsx
+++ b/app/mini/app/layout.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { ReactNode, useEffect } from "react";
+import { usePathname } from "next/navigation";
+import AppShell from "@/components/app/AppShell";
+import { applyTelegramTheme, initTelegram, onTelegramEvent } from "@/lib/telegram";
+
+export default function MiniAppLayout({ children }: { children: ReactNode }) {
+  const pathname = usePathname() ?? "/mini/app";
+  const activeRoute = pathname.replace(/^\/mini/, "") || "/app";
+
+  useEffect(() => {
+    const webApp = initTelegram(() => applyTelegramTheme());
+    if (!webApp) return;
+    const unsubscribe = onTelegramEvent("themeChanged", () => applyTelegramTheme());
+    return () => {
+      unsubscribe();
+    };
+  }, []);
+
+  return (
+    <AppShell activeRoute={activeRoute.startsWith("/app") ? activeRoute : `/app${activeRoute}`} isMiniApp>
+      {children}
+    </AppShell>
+  );
+}

--- a/app/mini/app/page.tsx
+++ b/app/mini/app/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/app/app/page";

--- a/app/mini/app/recipes/page.tsx
+++ b/app/mini/app/recipes/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/app/app/recipes/page";

--- a/app/mini/app/settings/page.tsx
+++ b/app/mini/app/settings/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/app/app/settings/page";

--- a/app/mini/app/team/page.tsx
+++ b/app/mini/app/team/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/app/app/team/page";

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,15 @@
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <main className="container-soft py-16 text-center">
+      <h1 className="text-3xl font-semibold text-text" style={{ fontFamily: "var(--font-jost)" }}>
+        Страница не найдена
+      </h1>
+      <p className="mt-3 text-muted">Проверьте адрес или вернитесь на главную.</p>
+      <Link href="/" className="mt-6 inline-block underline text-primary">
+        На главную →
+      </Link>
+    </main>
+  );
+}

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import clsx from "clsx";
+import { useAppStore } from "@/lib/store";
+import { showToast } from "@/lib/toast";
+import { trackEvent } from "@/lib/analytics";
+
+const focusOptions = [
+  { id: "docs", title: "Документы", description: "Договоры, письма и длинные тексты" },
+  { id: "explain", title: "Объяснения", description: "Быстро и простыми словами" },
+  { id: "ideas", title: "Идеи", description: "Подборки и сценарии для вдохновения" },
+];
+
+const automationOptions = [
+  { id: "auto", title: "Авто", description: "Просто рассказываете задачу — мы подберём рецепт", badge: "Рекомендуем" },
+  { id: "manual", title: "Вручную", description: "Выбирайте модели и рецепты самостоятельно" },
+  { id: "mixed", title: "Комбинировать", description: "Авто + ручной контроль, можно переключаться" },
+];
+
+const presets = [
+  { id: "teacher", title: "Учителю", description: "Конспекты уроков, сценарии занятий и проверка работ" },
+  { id: "manager", title: "Менеджеру", description: "Отчёты, письма клиентам и расшифровка встреч" },
+  { id: "family", title: "Для семьи", description: "Рецепты, планирование дел и помощь с документами" },
+];
+
+export default function OnboardingPage() {
+  const router = useRouter();
+  const { auth, completeOnboarding } = useAppStore();
+  const { onboardingDone } = auth;
+
+  const [step, setStep] = useState(0);
+  const [focus, setFocus] = useState<string | null>(null);
+  const [mode, setMode] = useState<string | null>("auto");
+
+  useEffect(() => {
+    if (onboardingDone) {
+      router.replace("/app");
+    }
+  }, [onboardingDone, router]);
+
+  const totalSteps = 3;
+  const progress = useMemo(() => Math.round(((step + 1) / totalSteps) * 100), [step]);
+
+  const handleSkip = () => {
+    completeOnboarding();
+    trackEvent("onboarding_step", { step, action: "skip" });
+    router.push("/app");
+  };
+
+  const handleNext = () => {
+    if (step >= totalSteps - 1) {
+      completeOnboarding();
+      trackEvent("onboarding_step", { step: totalSteps, action: "complete" });
+      router.push("/app");
+      return;
+    }
+    const nextStep = Math.min(step + 1, totalSteps - 1);
+    trackEvent("onboarding_step", { step: nextStep + 1, action: "next" });
+    setStep((prev) => Math.min(prev + 1, totalSteps - 1));
+  };
+
+  const handlePrev = () => {
+    setStep((prev) => Math.max(prev - 1, 0));
+  };
+
+  const handlePreset = (id: string) => {
+    completeOnboarding();
+    trackEvent("onboarding_step", { step: totalSteps, action: "preset", presetId: id });
+    showToast("Пресет добавлен");
+    router.push("/app");
+  };
+
+  return (
+    <main className="min-h-screen bg-surface">
+      <div className="mx-auto flex min-h-screen w-full max-w-4xl flex-col gap-6 px-4 py-10 sm:px-6">
+        <header className="flex items-center justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.32em] text-primary">Добро пожаловать</p>
+            <h1 className="mt-2 text-3xl font-semibold text-text">Несколько вопросов для точного старта</h1>
+          </div>
+          <button
+            type="button"
+            onClick={handleSkip}
+            className="hidden rounded-xl border border-neutral-200/70 px-4 py-2 text-sm font-semibold text-muted transition hover:text-text sm:inline-flex"
+          >
+            Пропустить
+          </button>
+        </header>
+        <div>
+          <div
+            role="progressbar"
+            aria-valuenow={progress}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            className="relative h-2 overflow-hidden rounded-full bg-neutral-100"
+          >
+            <span className="absolute inset-y-0 left-0 rounded-full bg-primary transition-all" style={{ width: `${progress}%` }} />
+          </div>
+          <p className="mt-2 text-xs font-semibold text-muted">Шаг {step + 1} из {totalSteps}</p>
+        </div>
+        <section className="flex-1 rounded-3xl border border-neutral-200/70 bg-white/95 p-6 shadow-soft">
+          {step === 0 && (
+            <div className="space-y-6">
+              <div>
+                <h2 className="text-2xl font-semibold text-text">Что хотите сделать в первую очередь?</h2>
+                <p className="mt-2 text-sm text-muted">Выберите один вариант — мы предложим подходящие рецепты.</p>
+              </div>
+              <div className="grid gap-3 sm:grid-cols-3">
+                {focusOptions.map((option) => (
+                  <button
+                    key={option.id}
+                    type="button"
+                    onClick={() => setFocus(option.id)}
+                    className={clsx(
+                      "flex flex-col gap-2 rounded-2xl border px-4 py-5 text-left transition",
+                      focus === option.id
+                        ? "border-primary/50 bg-primary/5 text-text shadow-soft"
+                        : "border-neutral-200/70 bg-neutral-50/70 text-muted hover:text-text"
+                    )}
+                  >
+                    <span className="text-sm font-semibold text-text">{option.title}</span>
+                    <span className="text-xs text-muted">{option.description}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+          {step === 1 && (
+            <div className="space-y-6">
+              <div>
+                <h2 className="text-2xl font-semibold text-text">Как удобнее управлять результатами?</h2>
+                <p className="mt-2 text-sm text-muted">Можно переключаться позже в настройках.</p>
+              </div>
+              <div className="grid gap-3 sm:grid-cols-3">
+                {automationOptions.map((option) => (
+                  <button
+                    key={option.id}
+                    type="button"
+                    onClick={() => setMode(option.id)}
+                    className={clsx(
+                      "flex flex-col gap-2 rounded-2xl border px-4 py-5 text-left transition",
+                      mode === option.id
+                        ? "border-primary/50 bg-primary/5 text-text shadow-soft"
+                        : "border-neutral-200/70 bg-neutral-50/70 text-muted hover:text-text"
+                    )}
+                  >
+                    <span className="flex items-center justify-between text-sm font-semibold text-text">
+                      {option.title}
+                      {option.badge && (
+                        <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-primary">
+                          {option.badge}
+                        </span>
+                      )}
+                    </span>
+                    <span className="text-xs text-muted">{option.description}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+          {step === 2 && (
+            <div className="space-y-6">
+              <div>
+                <h2 className="text-2xl font-semibold text-text">Выберите стартовый пресет</h2>
+                <p className="mt-2 text-sm text-muted">Можем добавить сразу несколько — начните с одного.</p>
+              </div>
+              <div className="grid gap-3 sm:grid-cols-3">
+                {presets.map((preset) => (
+                  <button
+                    key={preset.id}
+                    type="button"
+                    onClick={() => handlePreset(preset.id)}
+                    className="flex flex-col gap-2 rounded-2xl border border-neutral-200/70 bg-neutral-50/70 px-4 py-5 text-left text-muted transition hover:border-primary/40 hover:bg-primary/5 hover:text-text"
+                  >
+                    <span className="text-sm font-semibold text-text">{preset.title}</span>
+                    <span className="text-xs text-muted">{preset.description}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+        </section>
+        <footer className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <button
+            type="button"
+            onClick={handleSkip}
+            className="inline-flex rounded-xl border border-neutral-200/70 px-4 py-2 text-sm font-semibold text-muted transition hover:text-text sm:hidden"
+          >
+            Пропустить
+          </button>
+          <div className="flex items-center justify-end gap-3">
+            <button
+              type="button"
+              onClick={handlePrev}
+              disabled={step === 0}
+              className="inline-flex items-center rounded-xl border border-neutral-200/70 px-4 py-2 text-sm font-semibold text-muted transition hover:text-text disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              Назад
+            </button>
+            <button
+              type="button"
+              onClick={handleNext}
+              className="inline-flex items-center rounded-xl bg-primary px-5 py-2 text-sm font-semibold text-white transition hover:bg-primary/90"
+            >
+              {step === totalSteps - 1 ? "Готово" : "Далее"}
+            </button>
+          </div>
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import Button from "@/components/Button";
@@ -24,19 +24,68 @@ import {
 } from "@/lib/data";
 import { getDeviceType, setUserProps, trackEvent, trackTimeToValue } from "@/lib/analytics";
 import { useDebouncedValue } from "@/lib/useDebouncedValue";
+import { showToast } from "@/lib/toast";
 
 const heroBadges = ["Рекомендовано учителями", "Рекомендовано менеджерами", "Рекомендовано родителями"];
 const chatChips = ["Сделай проще", "Объясни как ребёнку", "Списком", "Примеры", "Исправь ошибки"];
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
 
-function showToast(message: string) {
-  const el = document.getElementById("toast");
-  if (!el) return;
-  el.textContent = message;
-  el.classList.add("toast--visible");
-  window.clearTimeout((el as unknown as { timeout?: number }).timeout);
-  (el as unknown as { timeout?: number }).timeout = window.setTimeout(() => {
-    el.classList.remove("toast--visible");
-  }, 2400);
+function useFocusTrap(isOpen: boolean, ref: RefObject<HTMLElement | null>, refreshKey?: unknown) {
+  useEffect(() => {
+    const node = ref.current;
+
+    if (!isOpen || !node) {
+      return;
+    }
+
+    const focusFirst = () => {
+      const elements = Array.from(
+        node.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+      ).filter((element) => !element.hasAttribute("disabled") && element.getAttribute("aria-hidden") !== "true");
+
+      elements[0]?.focus();
+    };
+
+    focusFirst();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Tab") {
+        return;
+      }
+
+      const elements = Array.from(
+        node.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)
+      ).filter((element) => !element.hasAttribute("disabled") && element.getAttribute("aria-hidden") !== "true");
+
+      if (elements.length === 0) {
+        return;
+      }
+
+      const firstElement = elements[0];
+      const lastElement = elements[elements.length - 1];
+      const activeElement = document.activeElement as HTMLElement | null;
+
+      if (event.shiftKey) {
+        if (!activeElement || !node.contains(activeElement) || activeElement === firstElement) {
+          event.preventDefault();
+          lastElement.focus();
+        }
+        return;
+      }
+
+      if (!activeElement || !node.contains(activeElement) || activeElement === lastElement) {
+        event.preventDefault();
+        firstElement.focus();
+      }
+    };
+
+    node.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      node.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen, ref, refreshKey]);
 }
 
 type OnboardingStage = 0 | 1 | 2 | 3;
@@ -56,6 +105,13 @@ export default function Page() {
   const [reviewsPage, setReviewsPage] = useState(1);
   const [demoResultReady, setDemoResultReady] = useState(false);
   const [reviewRating, setReviewRating] = useState(5);
+
+  const onboardingDialogRef = useRef<HTMLDivElement>(null);
+  const planDialogRef = useRef<HTMLDivElement>(null);
+  const reviewsDialogRef = useRef<HTMLDivElement>(null);
+  const onboardingDialogTitleId = "onboarding-dialog-title";
+  const planDialogTitleId = "plan-dialog-title";
+  const reviewsDialogTitleId = "reviews-dialog-title";
 
   const activePlan = plans.find((plan) => plan.id === selectedPlanId) ?? null;
 
@@ -135,6 +191,47 @@ export default function Page() {
     return fullReviews.slice(start, start + reviewsPerPage);
   }, [fullReviews, reviewsPage, reviewsPerPage]);
 
+  useFocusTrap(onboardingOpen, onboardingDialogRef, demoResultReady);
+  useFocusTrap(Boolean(activePlan), planDialogRef, selectedPlanId);
+  useFocusTrap(reviewsModalOpen, reviewsDialogRef, `${reviewsPage}-${paginatedReviews.length}`);
+
+  const closeOnboarding = useCallback(() => {
+    setOnboardingOpen(false);
+    onboardingTimers.current.forEach((timer) => window.clearTimeout(timer));
+    onboardingTimers.current = [];
+    onboardingStartedAt.current = null;
+    setDemoResultReady(false);
+  }, []);
+
+  useEffect(() => {
+    if (!onboardingOpen && !activePlan && !reviewsModalOpen) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== "Escape") {
+        return;
+      }
+
+      if (reviewsModalOpen) {
+        setReviewsModalOpen(false);
+        return;
+      }
+
+      if (activePlan) {
+        setSelectedPlanId(null);
+        return;
+      }
+
+      if (onboardingOpen) {
+        closeOnboarding();
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [activePlan, closeOnboarding, onboardingOpen, reviewsModalOpen]);
+
   const startOnboarding = () => {
     onboardingTimers.current.forEach((timer) => window.clearTimeout(timer));
     onboardingTimers.current = [];
@@ -154,14 +251,6 @@ export default function Page() {
         showToast("Готово. Сохраните, поделитесь или запустите следующий рецепт.");
       }, 2000)
     );
-  };
-
-  const closeOnboarding = () => {
-    setOnboardingOpen(false);
-    onboardingTimers.current.forEach((timer) => window.clearTimeout(timer));
-    onboardingTimers.current = [];
-    onboardingStartedAt.current = null;
-    setDemoResultReady(false);
   };
 
   const handleHeroCTA = () => {
@@ -220,8 +309,8 @@ export default function Page() {
 
   return (
     <main className="pb-24 md:pb-0">
-      <section id="hero" className="hero-surface relative overflow-hidden pb-16 pt-24 lg:pt-28">
-        <div className="container-soft grid items-center gap-12 lg:grid-cols-[minmax(0,1fr)_minmax(0,420px)]">
+      <section id="hero" className="hero-surface relative overflow-hidden pb-12 pt-20 md:pb-16 md:pt-24">
+        <div className="container-soft grid items-center gap-10 md:gap-12 lg:grid-cols-[minmax(0,1fr)_minmax(0,420px)]">
           <div className="space-y-6">
             <span className="inline-flex items-center gap-2 rounded-full bg-white/80 px-4 py-2 text-sm font-semibold text-primary">
               Понятный помощник
@@ -255,8 +344,8 @@ export default function Page() {
               ))}
             </div>
           </div>
-          <Card className="relative overflow-hidden border border-white/60 bg-white/90 p-0 shadow-[0_32px_80px_-44px_rgba(15,18,34,0.6)]">
-            <div className="space-y-5 p-6">
+          <Card className="relative overflow-hidden border border-white/60 bg-white/90 shadow-[0_24px_60px_-36px_rgba(15,18,34,0.3)]">
+            <div className="space-y-5">
               <div className="flex items-center justify-between text-xs font-semibold uppercase tracking-[0.2em] text-muted">
                 <span>Рецепт</span>
                 <span className="text-success">Готово на 100%</span>
@@ -315,7 +404,7 @@ export default function Page() {
         title="Как это работает"
         subtitle="Три понятных шага — и всё готово."
       >
-        <div className="grid gap-6 md:grid-cols-3">
+        <div className="grid gap-4 md:grid-cols-3 md:gap-5">
           {howSteps.map((step) => (
             <Card key={step.id} className="flex flex-col gap-4 p-0">
               <Image
@@ -323,11 +412,11 @@ export default function Page() {
                 alt={step.title}
                 width={360}
                 height={220}
-                sizes="(min-width: 1024px) 360px, (min-width: 768px) 50vw, 100vw"
+                sizes="(max-width: 768px) 100vw, (max-width: 1280px) 50vw, 360px"
                 className="h-48 w-full rounded-t-[20px] object-cover"
                 loading="lazy"
               />
-              <div className="space-y-2 p-6">
+              <div className="space-y-2 p-5 md:p-6">
                 <h3 className="text-lg font-semibold text-text">{step.title}</h3>
                 <p className="text-sm text-muted">{step.placeholder}</p>
                 <p className="text-sm text-muted">{step.helper}</p>
@@ -342,8 +431,8 @@ export default function Page() {
         </div>
       </Section>
 
-      <Section id="recipes" title="Готовые рецепты" subtitle="Начните с простого — так быстрее получается.">
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+      <Section id="recipes" title="Готовые рецепты" subtitle="Начните с простого — так быстрее получается." spacing="tight">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
           <div className="w-full max-w-xl">
             <label htmlFor="recipe-search" className="sr-only">
               Напишите, что нужно сделать — мы предложим рецепт
@@ -395,7 +484,7 @@ export default function Page() {
             ))}
           </div>
         </div>
-        <div className="mt-8 grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
+        <div className="mt-8 grid grid-cols-1 gap-4 md:grid-cols-2 md:gap-5 xl:grid-cols-3">
           {featuredRecipes.map((recipe) => (
             <div key={recipe.id} className="md:col-span-2 xl:col-span-1">
               <RecipeCard recipe={recipe} tab={activeTab} onLaunch={handleLaunchRecipe} variant="featured" />
@@ -415,7 +504,7 @@ export default function Page() {
         </div>
       </Section>
 
-      <Section id="chat" title="Обычный чат" subtitle="Можно говорить голосом или писать текстом.">
+      <Section id="chat" title="Обычный чат" subtitle="Можно говорить голосом или писать текстом." spacing="tight" tone="muted">
         <Card className="space-y-5">
           <div className="flex items-center gap-3 rounded-[20px] border border-neutral-200 bg-white px-4 py-5">
             <button
@@ -457,12 +546,12 @@ export default function Page() {
         <ModelTable />
       </Section>
 
-      <Section id="privacy" title="Приватность" subtitle="Вы решаете, что хранить.">
+      <Section id="privacy" title="Приватность" subtitle="Вы решаете, что хранить." spacing="tight">
         <div className="mb-6 inline-flex items-center gap-2 rounded-full bg-white px-4 py-2 text-xs font-semibold text-muted">
           <span aria-hidden>🛡️</span>
           Надёжные провайдеры в ЕС • Совместимо с требованиями РФ
         </div>
-        <div className="grid gap-4 md:grid-cols-3">
+        <div className="grid gap-4 md:grid-cols-3 md:gap-5">
           {privacyCards.map((card) => (
             <Card key={card.title} className="flex h-full flex-col justify-between">
               <div>
@@ -481,18 +570,20 @@ export default function Page() {
         </div>
       </Section>
 
+      <div className="section-divider my-8 md:my-10" />
+
       <Section
         id="pricing"
         title="Тарифы"
         subtitle="Оплата картой, СБП и МИР. Отмена — в один клик."
       >
-        <div className="grid gap-4 md:grid-cols-3">
+        <div className="grid gap-4 md:grid-cols-3 md:gap-5">
           {plans.map((plan) => (
             <Card
               key={plan.id}
               className={`flex h-full flex-col ${plan.highlight ? "border-primary-300 bg-primary-50" : "bg-white"}`}
             >
-              <div className="space-y-3 p-6">
+              <div className="space-y-3">
                 <div className="flex items-center justify-between">
                   <span className="text-xl font-semibold text-text">{plan.name}</span>
                   {plan.highlight && (
@@ -509,7 +600,7 @@ export default function Page() {
                   ))}
                 </ul>
               </div>
-              <div className="mt-auto space-y-2 p-6 pt-0">
+              <div className="mt-auto space-y-2 pt-4 md:pt-5">
                 <Button className="w-full" onClick={() => openPlanModal(plan.id)} aria-label={`Выбрать тариф ${plan.name}`}>
                   Выбрать
                 </Button>
@@ -535,7 +626,7 @@ export default function Page() {
         )}
       </Section>
 
-      <Section id="testimonials" title="Отзывы" subtitle="До и после — коротко и по делу.">
+      <Section id="testimonials" title="Отзывы" subtitle="До и после — коротко и по делу." spacing="tight" tone="muted">
         <div className="flex flex-col gap-4">
           <div className="text-sm font-semibold text-muted">★ 4,8 (за 30 дней)</div>
           <div className="-mx-6 flex snap-x snap-mandatory gap-4 overflow-x-auto px-6 pb-4" role="region" aria-label="Истории пользователей">
@@ -556,8 +647,10 @@ export default function Page() {
         </div>
       </Section>
 
-      <Section id="faq" title="FAQ" subtitle="Ответы на самые частые вопросы.">
-        <div className="grid gap-4 md:grid-cols-2">
+      <div className="section-divider my-8 md:my-10" />
+
+      <Section id="faq" title="FAQ" subtitle="Ответы на самые частые вопросы." spacing="tight">
+        <div className="grid gap-4 md:grid-cols-2 md:gap-5">
           {faqs.map((faq) => (
             <FAQItem key={faq.id} {...faq} />
           ))}
@@ -592,17 +685,26 @@ export default function Page() {
 
       {onboardingOpen && (
         <div
-          role="dialog"
-          aria-modal="true"
           className="fixed inset-0 z-50 flex items-center justify-center bg-[rgba(15,18,34,0.55)] px-4"
+          onClick={closeOnboarding}
         >
-          <Card className="w-full max-w-lg bg-white">
-            <div className="flex items-center justify-between">
-              <h3 className="text-xl font-semibold text-text">Первый результат</h3>
-              <button type="button" aria-label="Закрыть" onClick={closeOnboarding} className="text-muted">
-                ✕
-              </button>
-            </div>
+          <div
+            ref={onboardingDialogRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={onboardingDialogTitleId}
+            className="w-full max-w-lg"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <Card className="w-full bg-white">
+              <div className="flex items-center justify-between">
+                <h3 id={onboardingDialogTitleId} className="text-xl font-semibold text-text">
+                  Первый результат
+                </h3>
+                <button type="button" aria-label="Закрыть" onClick={closeOnboarding} className="text-muted">
+                  ✕
+                </button>
+              </div>
             <div className="mt-4 space-y-4">
               <p className="text-sm text-muted">Шаг {onboardingStage + 1} из 3</p>
               <div className="h-2 w-full overflow-hidden rounded-full bg-neutral-100">
@@ -636,23 +738,33 @@ export default function Page() {
                 </div>
               )}
             </div>
-          </Card>
+            </Card>
+          </div>
         </div>
       )}
 
       {activePlan && (
         <div
-          role="dialog"
-          aria-modal="true"
           className="fixed inset-0 z-50 flex items-center justify-center bg-[rgba(15,18,34,0.55)] px-4"
+          onClick={() => setSelectedPlanId(null)}
         >
-          <Card className="w-full max-w-md bg-white">
-            <div className="flex items-center justify-between">
-              <h3 className="text-xl font-semibold text-text">Оплата тарифа «{activePlan.name}»</h3>
-              <button type="button" aria-label="Закрыть" onClick={() => setSelectedPlanId(null)} className="text-muted">
-                ✕
-              </button>
-            </div>
+          <div
+            ref={planDialogRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={planDialogTitleId}
+            className="w-full max-w-md"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <Card className="w-full bg-white">
+              <div className="flex items-center justify-between">
+                <h3 id={planDialogTitleId} className="text-xl font-semibold text-text">
+                  Оплата тарифа «{activePlan.name}»
+                </h3>
+                <button type="button" aria-label="Закрыть" onClick={() => setSelectedPlanId(null)} className="text-muted">
+                  ✕
+                </button>
+              </div>
             <p className="mt-2 text-sm text-muted">Выберите удобный способ оплаты.</p>
             <div className="mt-4 space-y-3">
               {["Карта", "СБП", "МИР"].map((method) => (
@@ -666,23 +778,33 @@ export default function Page() {
                 </Button>
               ))}
             </div>
-          </Card>
+            </Card>
+          </div>
         </div>
       )}
 
       {reviewsModalOpen && (
         <div
-          role="dialog"
-          aria-modal="true"
           className="fixed inset-0 z-50 flex items-center justify-center bg-[rgba(15,18,34,0.55)] px-4"
+          onClick={() => setReviewsModalOpen(false)}
         >
-          <Card className="w-full max-w-4xl bg-white">
-            <div className="flex items-center justify-between">
-              <h3 className="text-xl font-semibold text-text">Отзывы пользователей</h3>
-              <button type="button" aria-label="Закрыть" onClick={() => setReviewsModalOpen(false)} className="text-muted">
-                ✕
-              </button>
-            </div>
+          <div
+            ref={reviewsDialogRef}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={reviewsDialogTitleId}
+            className="w-full max-w-4xl"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <Card className="w-full bg-white">
+              <div className="flex items-center justify-between">
+                <h3 id={reviewsDialogTitleId} className="text-xl font-semibold text-text">
+                  Отзывы пользователей
+                </h3>
+                <button type="button" aria-label="Закрыть" onClick={() => setReviewsModalOpen(false)} className="text-muted">
+                  ✕
+                </button>
+              </div>
             <div className="mt-4 grid gap-4 md:grid-cols-2">
               {paginatedReviews.map((review) => (
                 <Card key={review.id} className="bg-neutral-50">
@@ -736,7 +858,8 @@ export default function Page() {
                 </Button>
               </form>
             </div>
-          </Card>
+            </Card>
+          </div>
         </div>
       )}
     </main>

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,8 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [{ userAgent: "*", allow: "/" }],
+    sitemap: "https://prostoii.ru/sitemap.xml"
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,12 @@
+import type { MetadataRoute } from "next";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const base = "https://prostoii.ru";
+  const paths = ["/", "/privacy", "/data-storage", "/settings/privacy"];
+  return paths.map((path) => ({
+    url: `${base}${path}`,
+    lastModified: new Date(),
+    changeFrequency: "weekly",
+    priority: path === "/" ? 1 : 0.6
+  }));
+}

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -5,7 +5,7 @@ export default function Card({ className, ...props }: HTMLAttributes<HTMLDivElem
   return (
     <div
       className={clsx(
-        "rounded-[20px] border border-neutral-200/70 bg-white/95 p-6 shadow-[0_24px_64px_-40px_rgba(15,18,34,0.45)] transition-all hover:-translate-y-0.5 hover:shadow-[0_32px_80px_-36px_rgba(15,18,34,0.55)]",
+        "rounded-[20px] border border-neutral-200/70 bg-white/95 p-5 shadow-soft transition-all hover:-translate-y-0.5 hover:shadow-soft-lg md:p-6",
         className
       )}
       {...props}

--- a/components/ModelTable.tsx
+++ b/components/ModelTable.tsx
@@ -19,7 +19,8 @@ const rows = [
 ];
 
 export default function ModelTable() {
-  const { autoModel, setAutoModel } = useAppStore();
+  const { preferences, setAutoModel } = useAppStore();
+  const autoModel = preferences.autoModel;
 
   return (
     <Card className="overflow-hidden p-0">

--- a/components/RecipeCard.tsx
+++ b/components/RecipeCard.tsx
@@ -16,7 +16,7 @@ export default function RecipeCard({ recipe, onLaunch, tab, variant = "default" 
     <Card className={clsx("relative h-full overflow-hidden p-0", variant === "featured" && "bg-neutral-50")}>
       <button
         type="button"
-        className="flex h-full w-full flex-col gap-4 rounded-[20px] p-6 text-left transition"
+        className="flex h-full w-full flex-col gap-4 rounded-[20px] p-5 text-left transition md:p-6"
         onClick={() => onLaunch(recipe, tab)}
         aria-label={`Запустить рецепт «${recipe.title}»`}
       >

--- a/components/Section.tsx
+++ b/components/Section.tsx
@@ -1,6 +1,9 @@
 import { ReactNode } from "react";
 import clsx from "clsx";
 
+type SectionSpacing = "normal" | "tight";
+type SectionTone = "default" | "muted";
+
 type Props = {
   id?: string;
   title: string;
@@ -8,18 +11,44 @@ type Props = {
   eyebrow?: string;
   children: ReactNode;
   className?: string;
+  spacing?: SectionSpacing;
+  tone?: SectionTone;
 };
 
-export default function Section({ id, title, subtitle, eyebrow, children, className }: Props) {
+const spacingClasses: Record<SectionSpacing, string> = {
+  normal: "py-14 md:py-20",
+  tight: "py-10 md:py-14"
+};
+
+const headerSpacing: Record<SectionSpacing, string> = {
+  normal: "mb-12",
+  tight: "mb-8"
+};
+
+const toneClasses: Record<SectionTone, string> = {
+  default: "",
+  muted: "bg-muted"
+};
+
+export default function Section({
+  id,
+  title,
+  subtitle,
+  eyebrow,
+  children,
+  className,
+  spacing = "normal",
+  tone = "default"
+}: Props) {
   return (
-    <section id={id} className={clsx("py-16 lg:py-24", className)}>
+    <section id={id} className={clsx(spacingClasses[spacing], toneClasses[tone], className)}>
       <div className="container-soft">
-        <div className="mb-10 max-w-3xl">
+        <div className={clsx("max-w-3xl", headerSpacing[spacing])}>
           {eyebrow && <span className="text-sm font-semibold uppercase tracking-[0.24em] text-primary">{eyebrow}</span>}
           <h2 className="mt-3 text-[32px] font-semibold leading-[1.2] text-text md:text-4xl" style={{ fontFamily: "var(--font-jost)" }}>
             {title}
           </h2>
-          {subtitle && <p className="mt-3 text-lg leading-relaxed text-muted">{subtitle}</p>}
+          {subtitle && <p className="mt-2 text-base leading-relaxed text-muted md:text-lg">{subtitle}</p>}
         </div>
         {children}
       </div>

--- a/components/TestimonialCard.tsx
+++ b/components/TestimonialCard.tsx
@@ -17,7 +17,7 @@ export default function TestimonialCard({ id, name, role, rating, before, after,
   const stars = Array.from({ length: 5 }, (_, index) => (index < rating ? "★" : "☆")).join("");
 
   return (
-    <Card className={clsx("min-w-[280px] snap-center scroll-ml-6 rounded-[20px] border border-neutral-200/60 bg-white p-6 lg:min-w-[320px]", className)}>
+    <Card className={clsx("min-w-[280px] snap-center scroll-ml-6 rounded-[20px] border border-neutral-200/60 bg-white lg:min-w-[320px]", className)}>
       <div className="flex items-center gap-3">
         <Image
           src={image}

--- a/components/app/AppShell.tsx
+++ b/components/app/AppShell.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { ReactNode, useEffect } from "react";
+import clsx from "clsx";
+import Sidebar from "./Sidebar";
+import TopBar from "./TopBar";
+import BottomTabBar from "./BottomTabBar";
+import { useAppStore } from "@/lib/store";
+
+type AppShellProps = {
+  children: ReactNode;
+  activeRoute: string;
+  isMiniApp?: boolean;
+};
+
+export default function AppShell({ children, activeRoute, isMiniApp = false }: AppShellProps) {
+  const { ui, setIsMiniApp, setSidebarOpen, toggleSidebar } = useAppStore();
+  const { sidebarOpen } = ui;
+
+  useEffect(() => {
+    setIsMiniApp(isMiniApp);
+    if (isMiniApp) {
+      setSidebarOpen(false);
+    }
+  }, [isMiniApp, setIsMiniApp, setSidebarOpen]);
+
+  useEffect(() => {
+    setSidebarOpen(false);
+  }, [activeRoute, setSidebarOpen]);
+
+  return (
+    <div className={clsx("min-h-screen", isMiniApp ? "bg-surface" : "bg-muted")}>
+      {!isMiniApp && (
+        <Sidebar
+          activeRoute={activeRoute}
+          variant="overlay"
+          isOpen={sidebarOpen}
+          onClose={() => setSidebarOpen(false)}
+        />
+      )}
+      <div className="flex min-h-screen">
+        {!isMiniApp && <Sidebar activeRoute={activeRoute} variant="desktop" />}
+        <div className="flex min-h-screen flex-1 flex-col">
+          <TopBar onMenuToggle={toggleSidebar} isMiniApp={isMiniApp} />
+          <main
+            className={clsx(
+              "flex-1",
+              isMiniApp
+                ? "px-3 pb-6 pt-4"
+                : "px-4 pb-28 pt-6 sm:px-6 lg:px-10 lg:pb-12 lg:pt-8"
+            )}
+          >
+            <div
+              className={clsx(
+                "mx-auto w-full",
+                isMiniApp ? "max-w-3xl space-y-5" : "max-w-6xl space-y-8 lg:space-y-10"
+              )}
+            >
+              {children}
+            </div>
+          </main>
+        </div>
+      </div>
+      <BottomTabBar activeRoute={activeRoute} isMiniApp={isMiniApp} />
+    </div>
+  );
+}

--- a/components/app/BottomTabBar.tsx
+++ b/components/app/BottomTabBar.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import Link from "next/link";
+import clsx from "clsx";
+import { navigationItems } from "./navigation";
+
+type BottomTabBarProps = {
+  activeRoute: string;
+  isMiniApp?: boolean;
+};
+
+export default function BottomTabBar({ activeRoute, isMiniApp = false }: BottomTabBarProps) {
+  if (isMiniApp) return null;
+
+  return (
+    <nav
+      aria-label="Нижняя навигация"
+      className="fixed inset-x-0 bottom-0 z-30 border-t border-neutral-200/70 bg-white/95 backdrop-blur lg:hidden"
+    >
+      <ul className="mx-auto flex max-w-md items-stretch justify-between px-4 py-2">
+        {navigationItems.map((item) => {
+          const isActive = activeRoute.startsWith(item.href);
+          const ItemIcon = item.icon;
+          return (
+            <li key={item.href} className="flex flex-1 justify-center">
+              <Link
+                href={item.href}
+                aria-current={isActive ? "page" : undefined}
+                className={clsx(
+                  "flex w-full flex-col items-center gap-1 rounded-xl px-3 py-2 text-xs font-medium transition",
+                  isActive ? "text-primary" : "text-muted hover:text-text"
+                )}
+              >
+                <ItemIcon className={clsx("h-5 w-5", isActive ? "text-primary" : "text-muted")}
+                  focusable="false"
+                />
+                <span>{item.label}</span>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/components/app/Sidebar.tsx
+++ b/components/app/Sidebar.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import Link from "next/link";
+import clsx from "clsx";
+import { navigationItems } from "./navigation";
+import { useAppStore } from "@/lib/store";
+import { useMemo } from "react";
+
+type SidebarProps = {
+  activeRoute: string;
+  variant: "desktop" | "overlay";
+  isOpen?: boolean;
+  onClose?: () => void;
+};
+
+export default function Sidebar({ activeRoute, variant, isOpen = false, onClose }: SidebarProps) {
+  const { auth, logout } = useAppStore();
+  const { user } = auth;
+
+  const navItems = useMemo(() => navigationItems, []);
+
+  const content = (
+    <div className="flex h-full flex-col gap-6">
+      <div className="pt-4">
+        <Link href="/app" className="flex items-center gap-2 px-4 text-lg font-semibold text-text">
+          <span className="inline-flex h-9 w-9 items-center justify-center rounded-2xl bg-primary/10 font-heading text-primary">П</span>
+          ПростоИИ
+        </Link>
+      </div>
+      <nav className="flex-1 overflow-y-auto" aria-label="Основная навигация">
+        <ul className="space-y-1 px-2">
+          {navItems.map((item) => {
+            const isActive = activeRoute.startsWith(item.href);
+            const ItemIcon = item.icon;
+            return (
+              <li key={item.href}>
+                <Link
+                  href={item.href}
+                  aria-current={isActive ? "page" : undefined}
+                  className={clsx(
+                    "flex items-center gap-3 rounded-2xl px-4 py-3 text-sm font-semibold transition",
+                    isActive
+                      ? "bg-primary/10 text-primary shadow-soft"
+                      : "text-muted hover:bg-neutral-100/80 hover:text-text"
+                  )}
+                  onClick={variant === "overlay" ? onClose : undefined}
+                >
+                  <ItemIcon className={clsx("h-5 w-5", isActive ? "text-primary" : "text-muted")}
+                    focusable="false"
+                  />
+                  <span>{item.label}</span>
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+      <div className="space-y-3 px-4 pb-6">
+        <div className="rounded-2xl border border-neutral-200/70 bg-neutral-50/70 p-4">
+          {user ? (
+            <div className="flex items-center gap-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-sm font-semibold text-primary">
+                {user.name[0]}
+              </div>
+              <div className="flex-1">
+                <p className="text-sm font-semibold text-text">{user.name}</p>
+                <p className="text-xs text-muted">{user.role ?? "Личный аккаунт"}</p>
+              </div>
+            </div>
+          ) : (
+            <div>
+              <p className="text-sm font-semibold text-text">Гость</p>
+              <p className="mt-1 text-xs text-muted">Войдите, чтобы синхронизировать результаты и команды.</p>
+              <Link
+                href="/login"
+                className="mt-3 inline-flex items-center text-sm font-semibold text-primary hover:underline"
+                onClick={variant === "overlay" ? onClose : undefined}
+              >
+                Войти через Telegram
+              </Link>
+            </div>
+          )}
+        </div>
+        {user && (
+          <button
+            type="button"
+            onClick={logout}
+            className="w-full rounded-xl border border-neutral-200/70 bg-white px-4 py-2.5 text-sm font-semibold text-muted transition hover:text-text"
+          >
+            Выйти
+          </button>
+        )}
+      </div>
+    </div>
+  );
+
+  if (variant === "overlay") {
+    return (
+      <>
+        <div
+          role="presentation"
+          onClick={onClose}
+          className={clsx(
+            "fixed inset-0 z-40 bg-neutral-900/40 backdrop-blur-sm transition-opacity duration-200 lg:hidden",
+            isOpen ? "pointer-events-auto opacity-100" : "pointer-events-none opacity-0"
+          )}
+        />
+        <aside
+          className={clsx(
+            "fixed inset-y-0 left-0 z-50 w-72 bg-white px-3 pb-6 pt-3 shadow-xl transition-transform duration-200 lg:hidden",
+            isOpen ? "translate-x-0" : "-translate-x-full"
+          )}
+          aria-label="Меню приложения"
+        >
+          <div className="flex justify-end">
+            <button
+              type="button"
+              onClick={onClose}
+              className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-neutral-200/70 text-muted transition hover:text-text"
+              aria-label="Закрыть меню"
+            >
+              ×
+            </button>
+          </div>
+          {content}
+        </aside>
+      </>
+    );
+  }
+
+  return (
+    <aside className="hidden w-72 shrink-0 border-r border-neutral-200/60 bg-white px-3 pb-8 pt-6 lg:flex" aria-label="Меню приложения">
+      {content}
+    </aside>
+  );
+}

--- a/components/app/TopBar.tsx
+++ b/components/app/TopBar.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { ChangeEvent, useState } from "react";
+import clsx from "clsx";
+import { useAppStore } from "@/lib/store";
+
+type TopBarProps = {
+  onMenuToggle?: () => void;
+  isMiniApp?: boolean;
+};
+
+export default function TopBar({ onMenuToggle, isMiniApp = false }: TopBarProps) {
+  const {
+    auth: { user },
+  } = useAppStore();
+  const [query, setQuery] = useState("");
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setQuery(event.target.value);
+  };
+
+  return (
+    <header
+      className={clsx(
+        "sticky top-0 z-30 flex w-full items-center gap-3 border-b border-neutral-200/60 bg-white/95 backdrop-blur",
+        isMiniApp ? "px-3 py-2.5" : "px-4 py-3 sm:px-6 lg:px-8"
+      )}
+    >
+      <div className="flex flex-1 items-center gap-3">
+        {!isMiniApp && (
+          <button
+            type="button"
+            onClick={onMenuToggle}
+            className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-neutral-200/70 bg-white text-text transition hover:-translate-y-0.5 hover:shadow-soft focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary lg:hidden"
+            aria-label="Открыть меню"
+          >
+            <span aria-hidden className="text-lg">☰</span>
+          </button>
+        )}
+        <div className="min-w-0">
+          <p className="truncate text-sm font-semibold text-text">
+            {user ? `Здравствуйте, ${user.name.split(" ")[0]}!` : "ПростоИИ"}
+          </p>
+          <p className="hidden text-xs text-muted sm:block">Быстрые ответы и файлы — всегда под рукой.</p>
+        </div>
+      </div>
+      <div className="flex flex-1 items-center justify-end gap-3 sm:gap-4">
+        <label className={clsx("relative flex-1 max-w-sm items-center", isMiniApp ? "hidden sm:flex" : "hidden md:flex")}>
+          <span aria-hidden className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={1.8} className="h-4 w-4">
+              <circle cx={11} cy={11} r={6} />
+              <path d="m20 20-3.6-3.6" />
+            </svg>
+          </span>
+          <input
+            value={query}
+            onChange={handleChange}
+            type="search"
+            placeholder="Искать по заметкам"
+            aria-label="Поиск по истории"
+            className="w-full rounded-xl border border-neutral-200/70 bg-neutral-50/60 py-2 pl-10 pr-3 text-sm text-text placeholder:text-muted focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40"
+          />
+        </label>
+        <div className="flex items-center gap-2 rounded-xl border border-neutral-200/70 bg-neutral-50/70 px-3 py-2 text-xs font-semibold text-muted">
+          <span className="inline-flex h-2.5 w-2.5 rounded-full bg-success" aria-hidden />
+          <span className="text-muted">Лимиты: 24 / 50</span>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/components/app/navigation.tsx
+++ b/components/app/navigation.tsx
@@ -1,0 +1,127 @@
+import { ComponentProps } from "react";
+import clsx from "clsx";
+
+export type IconProps = ComponentProps<"svg">;
+
+const iconBase = "h-5 w-5";
+
+export const HomeIcon = ({ className, ...props }: IconProps) => (
+  <svg
+    aria-hidden
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.8}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={clsx(iconBase, className)}
+    {...props}
+  >
+    <path d="M4 10.5 12 4l8 6.5" />
+    <path d="M6.5 9.8V20h11V9.8" />
+  </svg>
+);
+
+export const RecipesIcon = ({ className, ...props }: IconProps) => (
+  <svg
+    aria-hidden
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.8}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={clsx(iconBase, className)}
+    {...props}
+  >
+    <path d="M5 4.8h8.6a2.4 2.4 0 0 1 2.4 2.4v12H7.4A2.4 2.4 0 0 1 5 16.8V4.8Z" />
+    <path d="M7.4 4.8V4a2 2 0 0 1 2-2H19v14.8a2 2 0 0 1-2 2h-1.6" />
+    <path d="M9.6 9.4h3.2M9.6 12.6h3.2" />
+  </svg>
+);
+
+export const ChatIcon = ({ className, ...props }: IconProps) => (
+  <svg
+    aria-hidden
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.8}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={clsx(iconBase, className)}
+    {...props}
+  >
+    <path d="M6.5 5.2h11a2.3 2.3 0 0 1 2.3 2.3v7.2a2.3 2.3 0 0 1-2.3 2.3H9.8L6 20.5V7.5A2.3 2.3 0 0 1 8.3 5.2Z" />
+    <path d="M9.2 10.1h6.6M9.2 13.1h4.1" />
+  </svg>
+);
+
+export const FilesIcon = ({ className, ...props }: IconProps) => (
+  <svg
+    aria-hidden
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.8}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={clsx(iconBase, className)}
+    {...props}
+  >
+    <path d="M6.2 4.6a2 2 0 0 1 2-2h4l3.6 3.6v11.2a2 2 0 0 1-2 2H8.2a2 2 0 0 1-2-2v-12Z" />
+    <path d="M12 2.6v3.6h3.8" />
+    <path d="M9.8 11.2h4.4M9.8 14.4h4.4" />
+  </svg>
+);
+
+export const TeamIcon = ({ className, ...props }: IconProps) => (
+  <svg
+    aria-hidden
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.8}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={clsx(iconBase, className)}
+    {...props}
+  >
+    <circle cx={8.5} cy={9} r={3} />
+    <circle cx={16.5} cy={10.6} r={2.4} />
+    <path d="M4.8 18.2a4 4 0 0 1 3.7-2.4h0.8a4 4 0 0 1 3.7 2.4" />
+    <path d="M13 18.8a3.4 3.4 0 0 1 3.2-2h0.7a3.4 3.4 0 0 1 3.1 1.9" />
+  </svg>
+);
+
+export const SettingsIcon = ({ className, ...props }: IconProps) => (
+  <svg
+    aria-hidden
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.8}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={clsx(iconBase, className)}
+    {...props}
+  >
+    <path d="m4.5 9.6 1.4-2.4 2.6.5a2.6 2.6 0 0 1 4.3-1.6l2-1.5 1.9 1.9-1.5 2a2.6 2.6 0 0 1 1.6 4.3l.5 2.6-2.4 1.4-1.7-1.9a2.6 2.6 0 0 1-4.5-1.2l-2.6-.5-.7-2.8Z" />
+    <circle cx={12} cy={12} r={2} />
+  </svg>
+);
+
+export type AppNavItem = {
+  label: string;
+  href: string;
+  icon: typeof HomeIcon;
+};
+
+export const navigationItems: AppNavItem[] = [
+  { label: "Главная", href: "/app", icon: HomeIcon },
+  { label: "Рецепты", href: "/app/recipes", icon: RecipesIcon },
+  { label: "Чат", href: "/app/chat", icon: ChatIcon },
+  { label: "Файлы", href: "/app/files", icon: FilesIcon },
+  { label: "Команда", href: "/app/team", icon: TeamIcon },
+  { label: "Настройки", href: "/app/settings", icon: SettingsIcon },
+];

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -22,7 +22,14 @@ type AnalyticsEvent =
   | "paywall_viewed"
   | "plan_selected"
   | "faq_opened"
-  | "review_submitted";
+  | "review_submitted"
+  | "login_success"
+  | "onboarding_step"
+  | "recipe_launch"
+  | "chat_send"
+  | "file_upload"
+  | "plan_upgrade"
+  | "privacy_change";
 
 const userProps: UserProps = {};
 

--- a/lib/store.tsx
+++ b/lib/store.tsx
@@ -1,17 +1,116 @@
 "use client";
 
-import { ReactNode, createContext, useContext, useMemo, useState } from "react";
+import { ReactNode, createContext, useCallback, useContext, useMemo, useState } from "react";
+
+export type AppUser = {
+  id: string;
+  name: string;
+  username?: string;
+  avatarUrl?: string;
+  role?: string;
+};
 
 type AppStore = {
-  autoModel: boolean;
+  auth: {
+    user: AppUser | null;
+    onboardingDone: boolean;
+    isMiniApp: boolean;
+  };
+  ui: {
+    sidebarOpen: boolean;
+  };
+  preferences: {
+    autoModel: boolean;
+  };
+  setUser: (user: AppUser | null) => void;
+  logout: () => void;
+  setOnboardingDone: (value: boolean) => void;
+  completeOnboarding: () => void;
+  setIsMiniApp: (value: boolean) => void;
+  setSidebarOpen: (value: boolean) => void;
+  toggleSidebar: () => void;
   setAutoModel: (value: boolean) => void;
 };
 
 const AppStoreContext = createContext<AppStore | undefined>(undefined);
 
 export function AppStateProvider({ children }: { children: ReactNode }) {
-  const [autoModel, setAutoModel] = useState(true);
-  const value = useMemo(() => ({ autoModel, setAutoModel }), [autoModel]);
+  const [user, setUser] = useState<AppUser | null>(null);
+  const [onboardingDone, setOnboardingDoneState] = useState(false);
+  const [isMiniApp, setIsMiniAppState] = useState(false);
+  const [sidebarOpen, setSidebarOpenState] = useState(false);
+  const [autoModel, setAutoModelState] = useState(true);
+
+  const handleSetUser = useCallback((nextUser: AppUser | null) => {
+    setUser(nextUser);
+  }, []);
+
+  const handleLogout = useCallback(() => {
+    setUser(null);
+  }, []);
+
+  const handleSetOnboardingDone = useCallback((value: boolean) => {
+    setOnboardingDoneState(value);
+  }, []);
+
+  const handleCompleteOnboarding = useCallback(() => {
+    setOnboardingDoneState(true);
+  }, []);
+
+  const handleSetIsMiniApp = useCallback((value: boolean) => {
+    setIsMiniAppState(value);
+  }, []);
+
+  const handleSetSidebarOpen = useCallback((value: boolean) => {
+    setSidebarOpenState(value);
+  }, []);
+
+  const handleToggleSidebar = useCallback(() => {
+    setSidebarOpenState((prev) => !prev);
+  }, []);
+
+  const handleSetAutoModel = useCallback((value: boolean) => {
+    setAutoModelState(value);
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      auth: {
+        user,
+        onboardingDone,
+        isMiniApp,
+      },
+      ui: {
+        sidebarOpen,
+      },
+      preferences: {
+        autoModel,
+      },
+      setUser: handleSetUser,
+      logout: handleLogout,
+      setOnboardingDone: handleSetOnboardingDone,
+      completeOnboarding: handleCompleteOnboarding,
+      setIsMiniApp: handleSetIsMiniApp,
+      setSidebarOpen: handleSetSidebarOpen,
+      toggleSidebar: handleToggleSidebar,
+      setAutoModel: handleSetAutoModel,
+    }),
+    [
+      autoModel,
+      handleCompleteOnboarding,
+      handleLogout,
+      handleSetAutoModel,
+      handleSetIsMiniApp,
+      handleSetOnboardingDone,
+      handleSetSidebarOpen,
+      handleSetUser,
+      handleToggleSidebar,
+      isMiniApp,
+      onboardingDone,
+      sidebarOpen,
+      user,
+    ]
+  );
 
   return <AppStoreContext.Provider value={value}>{children}</AppStoreContext.Provider>;
 }

--- a/lib/telegram.ts
+++ b/lib/telegram.ts
@@ -1,0 +1,90 @@
+export type TelegramThemeParams = {
+  bg_color?: string;
+  text_color?: string;
+  hint_color?: string;
+  button_color?: string;
+  button_text_color?: string;
+  secondary_bg_color?: string;
+  header_bg_color?: string;
+};
+
+type TelegramUser = {
+  id: number;
+  first_name: string;
+  last_name?: string;
+  username?: string;
+  photo_url?: string;
+};
+
+type TelegramEvent = "themeChanged" | "viewportChanged" | "mainButtonClicked" | "backButtonClicked";
+
+type TelegramWebApp = {
+  ready: () => void;
+  expand: () => void;
+  colorScheme: "light" | "dark";
+  themeParams: TelegramThemeParams;
+  initDataUnsafe?: { user?: TelegramUser };
+  onEvent: (event: TelegramEvent, handler: () => void) => void;
+  offEvent: (event: TelegramEvent, handler: () => void) => void;
+};
+
+declare global {
+  interface Window {
+    Telegram?: { WebApp?: TelegramWebApp };
+  }
+}
+
+export function getTelegramWebApp(): TelegramWebApp | null {
+  if (typeof window === "undefined") return null;
+  return window.Telegram?.WebApp ?? null;
+}
+
+export function isTelegramAvailable() {
+  return Boolean(getTelegramWebApp());
+}
+
+export function initTelegram(onReady?: (webApp: TelegramWebApp) => void) {
+  const webApp = getTelegramWebApp();
+  if (!webApp) return null;
+  webApp.ready();
+  try {
+    webApp.expand();
+  } catch (error) {
+    console.warn("[telegram] expand failed", error);
+  }
+  onReady?.(webApp);
+  return webApp;
+}
+
+export function applyTelegramTheme(theme?: TelegramThemeParams) {
+  if (typeof document === "undefined") return;
+  const webApp = getTelegramWebApp();
+  const params = theme ?? webApp?.themeParams;
+  if (!params) return;
+  const root = document.documentElement;
+
+  const mappings: Record<string, string | undefined> = {
+    "--surface": params.bg_color,
+    "--text": params.text_color,
+    "--muted": params.secondary_bg_color,
+    "--muted-text": params.hint_color,
+    "--primary": params.button_color,
+  };
+
+  Object.entries(mappings).forEach(([name, value]) => {
+    if (!value) return;
+    root.style.setProperty(name, value);
+  });
+}
+
+export function onTelegramEvent(event: TelegramEvent, handler: () => void) {
+  const webApp = getTelegramWebApp();
+  if (!webApp) return () => {};
+  webApp.onEvent(event, handler);
+  return () => webApp.offEvent(event, handler);
+}
+
+export function getTelegramUser(): TelegramUser | null {
+  const webApp = getTelegramWebApp();
+  return webApp?.initDataUnsafe?.user ?? null;
+}

--- a/lib/toast.ts
+++ b/lib/toast.ts
@@ -1,0 +1,18 @@
+"use client";
+
+type ToastElement = HTMLDivElement & { timeout?: number };
+
+export function showToast(message: string) {
+  if (typeof document === "undefined") return;
+  const el = document.getElementById("toast") as ToastElement | null;
+  if (!el) return;
+  el.textContent = message;
+  el.classList.add("toast--visible");
+  if (el.timeout) {
+    window.clearTimeout(el.timeout);
+  }
+  el.timeout = window.setTimeout(() => {
+    el.classList.remove("toast--visible");
+    el.timeout = undefined;
+  }, 2400);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "react-dom": "18.3.1"
       },
       "devDependencies": {
+        "@playwright/test": "1.48.0",
         "@types/node": "24.6.0",
         "@types/react": "19.1.15",
         "autoprefixer": "10.4.20",
@@ -491,6 +492,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.48.0.tgz",
+      "integrity": "sha512-W5lhqPUVPqhtc/ySvZI5Q8X2ztBOUgZ8LbAFy0JQgrXZs2xaILrUcNO3rQjwbLPfGK13+rZsDa1FpG+tqYkT5w==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.48.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -4379,6 +4396,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.48.0.tgz",
+      "integrity": "sha512-qPqFaMEHuY/ug8o0uteYJSRfMGFikhUysk8ZvAtfKmUK3kc/6oNl/y3EczF8OFGYIi/Ex2HspMfzYArk6+XQSA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.48.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.48.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.48.0.tgz",
+      "integrity": "sha512-RBvzjM9rdpP7UUFrQzRwR8L/xR4HyC1QXMzGYTbf1vjw25/ya9NRAVnXi/0fvFopjebvyPzsmoK58xxeEOaVvA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "clsx": "^2.1.1",
@@ -18,6 +19,7 @@
     "react-dom": "18.3.1"
   },
   "devDependencies": {
+    "@playwright/test": "1.48.0",
     "@types/node": "24.6.0",
     "@types/react": "19.1.15",
     "autoprefixer": "10.4.20",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "tests/e2e",
+  timeout: 30_000,
+  expect: { timeout: 5_000 },
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || "http://localhost:3000",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"], viewport: { width: 1280, height: 720 } },
+    },
+    {
+      name: "mobile",
+      use: { ...devices["Pixel 5"], viewport: { width: 375, height: 812 } },
+    },
+  ],
+  webServer: {
+    command: "npm run dev -- --hostname 0.0.0.0 --port 3000",
+    url: "http://localhost:3000",
+    timeout: 60_000,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/tests/e2e/app.spec.ts
+++ b/tests/e2e/app.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Dashboard", () => {
+  test("shows key blocks and keeps layout within viewport", async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 720 });
+    await page.goto("/app");
+    await expect(page.getByRole("heading", { name: "Домашняя" })).toBeVisible();
+    await expect(page.getByText("Последние результаты")).toBeVisible();
+    const hasHorizontalScroll = await page.evaluate(() => {
+      return document.documentElement.scrollWidth > window.innerWidth + 1;
+    });
+    expect(hasHorizontalScroll).toBeFalsy();
+  });
+});

--- a/tests/e2e/login.spec.ts
+++ b/tests/e2e/login.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Login page", () => {
+  test("renders telegram login CTA", async ({ page }) => {
+    await page.goto("/login");
+    await expect(page.getByRole("heading", { name: "Войдите через Telegram" })).toBeVisible();
+    const openButton = page.getByRole("link", { name: /Открыть в Telegram/i });
+    await expect(openButton).toHaveAttribute("href", /t.me/);
+    await expect(page.getByText("Мы используем Telegram только для авторизации", { exact: false })).toBeVisible();
+  });
+});

--- a/tests/e2e/onboarding.spec.ts
+++ b/tests/e2e/onboarding.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Onboarding flow", () => {
+  test("displays steps and allows skipping", async ({ page }) => {
+    await page.goto("/onboarding");
+    await expect(page.getByRole("heading", { name: "Несколько вопросов для точного старта" })).toBeVisible();
+    await expect(page.getByText("Шаг 1 из", { exact: false })).toBeVisible();
+    await page.getByRole("button", { name: "Далее" }).click();
+    await expect(page.getByText("Шаг 2 из", { exact: false })).toBeVisible();
+    await page.getByRole("button", { name: "Пропустить" }).click();
+    await expect(page).toHaveURL(/\/app$/);
+  });
+});


### PR DESCRIPTION
## Summary
- build a reusable app shell with expanded store state, desktop/mobile navigation, and Telegram mini-app handling
- ship login and onboarding flows plus dashboard sections with quick actions, history, pinned content, and analytics wiring
- add mini app routes and Playwright smoke tests to cover login, onboarding, and the new dashboard

## Testing
- npm run lint
- npm run build
- npx playwright install --with-deps chromium *(fails to download Chromium in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68db892643e48320b958f5af09c9d836