### PR TITLE
feat: add mock login and protected dashboards

### DIFF
--- a/app/app/layout.tsx
+++ b/app/app/layout.tsx
@@ -1,10 +1,27 @@
 "use client";
 
-import { ReactNode } from "react";
-import { usePathname } from "next/navigation";
+import { ReactNode, useEffect } from "react";
+import { usePathname, useRouter } from "next/navigation";
 import AppShell from "@/components/app/AppShell";
+import { useAppStore } from "@/lib/store";
 
 export default function AppLayout({ children }: { children: ReactNode }) {
   const pathname = usePathname() ?? "/app";
+  const router = useRouter();
+  const { auth, hydrated } = useAppStore();
+
+  useEffect(() => {
+    if (!hydrated) {
+      return;
+    }
+    if (!auth.user) {
+      router.replace("/login");
+    }
+  }, [auth.user, hydrated, router]);
+
+  if (!hydrated || !auth.user) {
+    return null;
+  }
+
   return <AppShell activeRoute={pathname}>{children}</AppShell>;
 }

--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -80,6 +80,39 @@ const typeLabels: Record<DashboardResult["type"], string> = {
   file: "Файл",
 };
 
+const navigationTiles = [
+  {
+    id: "recipes",
+    title: "Рецепты",
+    description: "Подбор готовых сценариев и инструкций",
+    href: "/app/recipes",
+  },
+  {
+    id: "chat",
+    title: "Чат",
+    description: "Диалог с ИИ простыми словами",
+    href: "/app/chat",
+  },
+  {
+    id: "files",
+    title: "Файлы",
+    description: "Загрузки, разборы и конспекты",
+    href: "/app/files",
+  },
+  {
+    id: "team",
+    title: "Команда",
+    description: "Совместная работа и роли",
+    href: "/app/team",
+  },
+  {
+    id: "settings",
+    title: "Настройки",
+    description: "Профиль, тариф и интеграции",
+    href: "/app/settings",
+  },
+];
+
 export default function DashboardPage() {
   const router = useRouter();
   const [results, setResults] = useState(initialResults);
@@ -122,6 +155,35 @@ export default function DashboardPage() {
 
   return (
     <div className="space-y-10 lg:space-y-12">
+      <section className="scroll-reveal">
+        <div className="flex flex-col gap-2">
+          <p className="text-xs font-semibold uppercase tracking-[0.32em] text-primary">Навигация</p>
+          <h2 className="text-xl font-semibold text-text">Быстрый переход по разделам</h2>
+        </div>
+        <div className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
+          {navigationTiles.map((tile) => (
+            <button
+              key={tile.id}
+              type="button"
+              onClick={() => router.push(tile.href)}
+              className="group flex flex-col items-start gap-3 rounded-2xl border border-neutral-200/70 bg-white/95 px-5 py-5 text-left shadow-soft transition hover:-translate-y-0.5 hover:shadow-soft-lg"
+            >
+              <span className="inline-flex items-center rounded-full bg-neutral-100 px-3 py-1 text-xs font-semibold text-muted">
+                Раздел
+              </span>
+              <span className="text-lg font-semibold text-text">{tile.title}</span>
+              <span className="text-sm text-muted">{tile.description}</span>
+              <span className="inline-flex items-center text-sm font-semibold text-primary">
+                Перейти
+                <span aria-hidden className="ml-1 transition group-hover:translate-x-0.5">
+                  →
+                </span>
+              </span>
+            </button>
+          ))}
+        </div>
+      </section>
+
       <section className="scroll-reveal">
         <div className="flex flex-col gap-2">
           <h1 className="text-3xl font-semibold text-text">Домашняя</h1>

--- a/app/mini/app/layout.tsx
+++ b/app/mini/app/layout.tsx
@@ -1,13 +1,16 @@
 "use client";
 
 import { ReactNode, useEffect } from "react";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import AppShell from "@/components/app/AppShell";
 import { applyTelegramTheme, initTelegram, onTelegramEvent } from "@/lib/telegram";
+import { useAppStore } from "@/lib/store";
 
 export default function MiniAppLayout({ children }: { children: ReactNode }) {
   const pathname = usePathname() ?? "/mini/app";
   const activeRoute = pathname.replace(/^\/mini/, "") || "/app";
+  const router = useRouter();
+  const { auth, hydrated } = useAppStore();
 
   useEffect(() => {
     const webApp = initTelegram(() => applyTelegramTheme());
@@ -17,6 +20,19 @@ export default function MiniAppLayout({ children }: { children: ReactNode }) {
       unsubscribe();
     };
   }, []);
+
+  useEffect(() => {
+    if (!hydrated) {
+      return;
+    }
+    if (!auth.user) {
+      router.replace("/login");
+    }
+  }, [auth.user, hydrated, router]);
+
+  if (!hydrated || !auth.user) {
+    return null;
+  }
 
   return (
     <AppShell activeRoute={activeRoute.startsWith("/app") ? activeRoute : `/app${activeRoute}`} isMiniApp>

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -27,8 +27,8 @@ const presets = [
 
 export default function OnboardingPage() {
   const router = useRouter();
-  const { auth, completeOnboarding } = useAppStore();
-  const { onboardingDone } = auth;
+  const { auth, completeOnboarding, hydrated } = useAppStore();
+  const { onboardingDone, user } = auth;
 
   const [step, setStep] = useState(0);
   const [focus, setFocus] = useState<string | null>(null);
@@ -39,6 +39,15 @@ export default function OnboardingPage() {
       router.replace("/app");
     }
   }, [onboardingDone, router]);
+
+  useEffect(() => {
+    if (!hydrated) {
+      return;
+    }
+    if (!user) {
+      router.replace("/login");
+    }
+  }, [hydrated, router, user]);
 
   const totalSteps = 3;
   const progress = useMemo(() => Math.round(((step + 1) / totalSteps) * 100), [step]);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from "react";
 import Image from "next/image";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import Button from "@/components/Button";
 import Card from "@/components/Card";
 import Section from "@/components/Section";
@@ -25,6 +26,7 @@ import {
 import { getDeviceType, setUserProps, trackEvent, trackTimeToValue } from "@/lib/analytics";
 import { useDebouncedValue } from "@/lib/useDebouncedValue";
 import { showToast } from "@/lib/toast";
+import { useAppStore } from "@/lib/store";
 
 const heroBadges = ["Рекомендовано учителями", "Рекомендовано менеджерами", "Рекомендовано родителями"];
 const chatChips = ["Сделай проще", "Объясни как ребёнку", "Списком", "Примеры", "Исправь ошибки"];
@@ -91,6 +93,8 @@ function useFocusTrap(isOpen: boolean, ref: RefObject<HTMLElement | null>, refre
 type OnboardingStage = 0 | 1 | 2 | 3;
 
 export default function Page() {
+  const router = useRouter();
+  const { auth } = useAppStore();
   const [activeTab, setActiveTab] = useState<RecipeCategory>("Популярные");
   const [searchValue, setSearchValue] = useState("");
   const debouncedSearch = useDebouncedValue(searchValue, 300);
@@ -254,9 +258,9 @@ export default function Page() {
   };
 
   const handleHeroCTA = () => {
-    trackEvent("hero_cta_clicked", { variant: "primary", device: getDeviceType() });
-    startOnboarding();
-    window.scrollTo({ top: 0, behavior: "smooth" });
+    const target = auth.user ? "/app" : "/login";
+    trackEvent("hero_cta_clicked", { variant: "primary", device: getDeviceType(), target });
+    router.push(target);
   };
 
   const handleExamplesClick = () => {
@@ -324,8 +328,12 @@ export default function Page() {
               </p>
             </div>
             <div className="flex flex-wrap gap-3">
-              <Button onClick={handleHeroCTA} aria-label="Начать бесплатно" size="lg">
-                Начать бесплатно
+              <Button
+                onClick={handleHeroCTA}
+                aria-label={auth.user ? "Перейти в дашборд" : "Начать бесплатно"}
+                size="lg"
+              >
+                {auth.user ? "Перейти в дашборд" : "Начать бесплатно"}
               </Button>
               <Button variant="link" onClick={handleExamplesClick} aria-label="Посмотреть примеры">
                 Посмотреть примеры

--- a/lib/store.tsx
+++ b/lib/store.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ReactNode, createContext, useCallback, useContext, useMemo, useState } from "react";
+import { ReactNode, createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
 
 export type AppUser = {
   id: string;
@@ -10,56 +10,147 @@ export type AppUser = {
   role?: string;
 };
 
-type AppStore = {
-  auth: {
-    user: AppUser | null;
-    onboardingDone: boolean;
-    isMiniApp: boolean;
+type AuthState = {
+  user: AppUser | null;
+  onboardingDone: boolean;
+  isMiniApp: boolean;
+};
+
+type PersistedAuthState = Pick<AuthState, "user" | "onboardingDone">;
+
+const AUTH_KEY = "prostoii_auth_v1";
+
+const defaultPersistedAuth: PersistedAuthState = {
+  user: null,
+  onboardingDone: false,
+};
+
+const defaultAuthState: AuthState = {
+  ...defaultPersistedAuth,
+  isMiniApp: false,
+};
+
+function getWindow() {
+  return typeof window === "undefined" ? null : window;
+}
+
+export function loadAuth(): PersistedAuthState {
+  const w = getWindow();
+  if (!w) {
+    return defaultPersistedAuth;
+  }
+
+  try {
+    const raw = w.localStorage.getItem(AUTH_KEY);
+    return raw ? (JSON.parse(raw) as PersistedAuthState) : defaultPersistedAuth;
+  } catch {
+    return defaultPersistedAuth;
+  }
+}
+
+export function saveAuth(state: PersistedAuthState) {
+  const w = getWindow();
+  if (!w) {
+    return;
+  }
+
+  try {
+    w.localStorage.setItem(AUTH_KEY, JSON.stringify(state));
+  } catch {
+    // ignore write errors (private mode, etc.)
+  }
+}
+
+export function loginMock(name?: string) {
+  const base = loadAuth();
+  const user: AppUser = {
+    id: `mock-${Date.now()}`,
+    name: name ?? "Demo User",
   };
+  const next: PersistedAuthState = {
+    user,
+    onboardingDone: base.onboardingDone,
+  };
+  saveAuth(next);
+  return next;
+}
+
+export function logout() {
+  saveAuth({ user: null, onboardingDone: false });
+}
+
+type AppStore = {
+  auth: AuthState;
   ui: {
     sidebarOpen: boolean;
   };
   preferences: {
     autoModel: boolean;
   };
+  hydrated: boolean;
+  setAuth: (value: Partial<AuthState> | ((prev: AuthState) => Partial<AuthState>)) => void;
   setUser: (user: AppUser | null) => void;
-  logout: () => void;
   setOnboardingDone: (value: boolean) => void;
   completeOnboarding: () => void;
   setIsMiniApp: (value: boolean) => void;
   setSidebarOpen: (value: boolean) => void;
   toggleSidebar: () => void;
   setAutoModel: (value: boolean) => void;
+  loginMock: (name?: string) => void;
+  logout: () => void;
 };
 
 const AppStoreContext = createContext<AppStore | undefined>(undefined);
 
 export function AppStateProvider({ children }: { children: ReactNode }) {
-  const [user, setUser] = useState<AppUser | null>(null);
-  const [onboardingDone, setOnboardingDoneState] = useState(false);
-  const [isMiniApp, setIsMiniAppState] = useState(false);
+  const [auth, setAuthState] = useState<AuthState>(() => ({
+    ...defaultAuthState,
+    ...loadAuth(),
+  }));
   const [sidebarOpen, setSidebarOpenState] = useState(false);
   const [autoModel, setAutoModelState] = useState(true);
+  const [hydrated, setHydrated] = useState(false);
 
-  const handleSetUser = useCallback((nextUser: AppUser | null) => {
-    setUser(nextUser);
+  useEffect(() => {
+    const persisted = loadAuth();
+    setAuthState((prev) => ({ ...prev, ...persisted }));
+    setHydrated(true);
   }, []);
 
+  useEffect(() => {
+    saveAuth({ user: auth.user, onboardingDone: auth.onboardingDone });
+  }, [auth.user, auth.onboardingDone]);
+
+  const handleSetAuth = useCallback(
+    (next: Partial<AuthState> | ((prev: AuthState) => Partial<AuthState>)) => {
+      setAuthState((prev) => {
+        const patch = typeof next === "function" ? next(prev) : next;
+        return { ...prev, ...patch };
+      });
+    },
+    []
+  );
+
+  const handleSetUser = useCallback((nextUser: AppUser | null) => {
+    handleSetAuth({ user: nextUser });
+  }, [handleSetAuth]);
+
   const handleLogout = useCallback(() => {
-    setUser(null);
+    logout();
+    setAuthState({ ...defaultAuthState });
   }, []);
 
   const handleSetOnboardingDone = useCallback((value: boolean) => {
-    setOnboardingDoneState(value);
-  }, []);
+    handleSetAuth({ onboardingDone: value });
+  }, [handleSetAuth]);
 
   const handleCompleteOnboarding = useCallback(() => {
-    setOnboardingDoneState(true);
-  }, []);
+    handleSetAuth({ onboardingDone: true });
+  }, [handleSetAuth]);
 
   const handleSetIsMiniApp = useCallback((value: boolean) => {
-    setIsMiniAppState(value);
-  }, []);
+    handleSetAuth({ isMiniApp: value });
+  }, [handleSetAuth]);
 
   const handleSetSidebarOpen = useCallback((value: boolean) => {
     setSidebarOpenState(value);
@@ -75,40 +166,42 @@ export function AppStateProvider({ children }: { children: ReactNode }) {
 
   const value = useMemo(
     () => ({
-      auth: {
-        user,
-        onboardingDone,
-        isMiniApp,
-      },
+      auth,
       ui: {
         sidebarOpen,
       },
       preferences: {
         autoModel,
       },
+      hydrated,
+      setAuth: handleSetAuth,
       setUser: handleSetUser,
-      logout: handleLogout,
       setOnboardingDone: handleSetOnboardingDone,
       completeOnboarding: handleCompleteOnboarding,
       setIsMiniApp: handleSetIsMiniApp,
       setSidebarOpen: handleSetSidebarOpen,
       toggleSidebar: handleToggleSidebar,
       setAutoModel: handleSetAutoModel,
+      loginMock: (name?: string) => {
+        const next = loginMock(name);
+        handleSetAuth({ user: next.user, onboardingDone: next.onboardingDone });
+      },
+      logout: handleLogout,
     }),
     [
       autoModel,
+      auth,
       handleCompleteOnboarding,
       handleLogout,
+      handleSetAuth,
       handleSetAutoModel,
       handleSetIsMiniApp,
       handleSetOnboardingDone,
       handleSetSidebarOpen,
       handleSetUser,
       handleToggleSidebar,
-      isMiniApp,
-      onboardingDone,
       sidebarOpen,
-      user,
+      hydrated,
     ]
   );
 


### PR DESCRIPTION
## Summary
- persist local auth state with helpers for mock login/logout
- add dev mock login entrypoint, hero CTA routing, and dashboard navigation tiles
- protect /app and /mini routes on the client and guard onboarding access

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbaa9aff288320876e8acdc692118f